### PR TITLE
fix: correct `BUNDLE_PATH` in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 DIR_NAME := $(notdir $(shell pwd))
-BUNDLE_PATH ?= ./bundle-examples/postgres14.bundle.yaml
+BUNDLE_PATH ?= ./bundle-examples/legacy.bundle.yaml
 PLATFORM ?= ubuntu@22.04:amd64
 MODEL_NAME ?= $(DIR_NAME)-build
 CLEAN_PLATFORM := $(subst :,-,$(PLATFORM))


### PR DESCRIPTION
https://warthogs.atlassian.net/browse/LNDENG-3531
## Description of changes

What does this change do?
Fixes the `BUNDLE_PATH` in the Makefile

## Rationale

Why make this change?
`make deploy` is affected as the previous file path was renamed

## Manual testing instructions

Steps to follow to verify the changes work.
run `make deploy` and ensure the process completes successfully.

## Checklist

Tick the boxes to affirm the following, or explain why it's not needed:

- [X] Tests passed locally
- [ ] Relevant documentation is updated (link PRs)

## Releases this PR should be backported to
N/A
Tick the boxes when the backport is merged.
N/A
- [ ] List them here
- [ ] List them here