### PR TITLE
fix: prefix `poetry run` for `ccc pack`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,10 +61,10 @@ make fmt
 
 ### Build the charm
 
-When developing the charm, you can use the [`ccc pack`](https://github.com/canonical/charmcraftcache) command to build the charm locally.
+When developing the charm, you can use the [`poetry run ccc pack`](https://github.com/canonical/charmcraftcache) command to build the charm locally.
 
 > [!NOTE]
-> Make sure you add this repository (https://github.com/canonical/landscape-charm) as a remote to your fork, otherwise `ccc` will fail.
+> Make sure you add this repository (<https://github.com/canonical/landscape-charm>) as a remote to your fork, otherwise `ccc` will fail.
 
 Use the following command to test the charm as it would be deployed by Juju in the `landscape-scalable` bundle:
 

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ fmt:
 
 # Charm building and deployment
 build:
-	ccc pack --platform $(PLATFORM)
+	poetry run ccc pack --platform $(PLATFORM)
 
 deploy:
 	@if [ "$(SKIP_CLEAN)" != "true" ]; then $(MAKE) clean; else echo "skipping clean..."; fi


### PR DESCRIPTION
Otherwise you have to install it manually with `pipx`.

## Manual testing

```sh
poetry run ccc pack
```