### PR TITLE
Add terraform tests for modern postgres interface

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,8 +1,5 @@
 # Landscape Server Charm Module
 
-> [!CAUTION]
-> This module is not currently compatible with Charmed PostgreSQL 16. You cannot relate it to the `16/stable`, `16/candidate`, `16/edge`, or `16/beta` channels of the `postgresql` charm.
-
 This directory contains a base [Terraform][Terraform] module for the [Landscape Server charm][Landscape Server charm].
 
 It uses the [Terraform Juju provider][Terraform Juju provider] to model the charm deployment onto any non-Kubernetes cloud managed by [Juju][Juju].
@@ -99,5 +96,5 @@ No modules.
 |------|-------------|
 | <a name="output_app_name"></a> [app\_name](#output\_app\_name) | Name of the deployed application. |
 | <a name="output_provides"></a> [provides](#output\_provides) | Map of integration endpoints this charm provides (`cos-agent`, `data`, `hosted`, `nrpe-external-master`, `website`). |
-| <a name="output_requires"></a> [requires](#output\_requires) | Map of integration endpoints this charm requires (`application-dashboard`, `db`, `amqp` or `inbound-amqp`/`outbound-amqp`). |
+| <a name="output_requires"></a> [requires](#output\_requires) | Map of integration endpoints this charm requires (`application-dashboard`, `db` or `db`/`database`, `amqp` or `inbound-amqp`/`outbound-amqp`). |
 <!-- END_TF_DOCS -->

--- a/terraform/tests/outputs.tftest.hcl
+++ b/terraform/tests/outputs.tftest.hcl
@@ -176,3 +176,64 @@ run "amqp_threshold_edge_case" {
     error_message = "Revision 142 should use modern amqp relations"
   }
 }
+
+run "modern_postgres_relations" {
+  command = plan
+
+  variables {
+    model    = "test-model"
+    channel  = "25.10/edge"
+    revision = 213
+    base     = "ubuntu@24.04"
+  }
+
+  assert {
+    condition     = output.requires.database == "database"
+    error_message = "Modern revision should have database relation"
+  }
+
+  assert {
+    condition     = output.requires.db == "db"
+    error_message = "Modern revision should have db relation"
+  }
+}
+
+run "legacy_postgres_relations" {
+  command = plan
+
+  variables {
+    model    = "test-model"
+    channel  = "25.10/edge"
+    revision = 212
+    base     = "ubuntu@24.04"
+  }
+
+  assert {
+    condition     = output.requires.db == "db"
+    error_message = "Legacy revision should have db relation"
+  }
+
+  assert {
+    condition     = !can(output.requires.database)
+    error_message = "Legacy revision should not have database relation"
+  }
+}
+
+run "modern_postgres_relations_null_revision" {
+  command = plan
+
+  variables {
+    model    = "test-model"
+    revision = null
+  }
+
+  assert {
+    condition     = output.requires.database == "database"
+    error_message = "Null revision should have database relation"
+  }
+
+  assert {
+    condition     = output.requires.db == "db"
+    error_message = "Null revision should have db relation"
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds comprehensive test coverage for the modern PostgreSQL interface support added in terraform/outputs.tf.

## Changes

- **New test cases:**
  - `modern_postgres_relations` - verifies revision >= 213 has both `database` and `db` relations
  - `legacy_postgres_relations` - verifies revision < 213 only has `db` relation
  - `modern_postgres_relations_null_revision` - verifies null revision defaults to modern behavior

- **Documentation updates:**
  - Removed outdated PostgreSQL 16 incompatibility warning
  - Updated outputs description to reflect new `database` relation support

## Testing

All tests pass:
```
make terraform-test
Success! 10 passed, 0 failed.
```

Manual validation:
```
terraform init -backend=false && terraform validate
Success! The configuration is valid.
```

## Related Changes

This complements the postgres interface logic introduced in terraform/outputs.tf (revision threshold: 213).