### PR TITLE
fix: add cosl to core deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ cosl = ">=1.0.0"
 coverage = "*"
 flake8 = "*"
 isort = "*"
-ops = { extras = ["testing"], version = "~=2.19" }
+ops = {extras = ["testing"], version = "~=2.19"}
 pydantic = "<2"
 pytest = "*"
 ruff = "*"
@@ -61,6 +61,8 @@ order-by-type = false
 case-sensitive = false
 
 [tool.pytest.ini_options]
-filterwarnings = ["once:.*Harness is deprecated.*:PendingDeprecationWarning"]
+filterwarnings = [
+    "once:.*Harness is deprecated.*:PendingDeprecationWarning"
+]
 pythonpath = [".", "lib", "src"]
 testpaths = ["tests"]


### PR DESCRIPTION
Based on the version from `internal-haproxy` (#38): https://github.com/canonical/landscape-server-operator/blob/9e8b60429c1538de23fc927fb90ff162b2d3af70/pyproject.toml

## Manual testing

Run `make deploy` and see that the charm starts up as usual. Without this fix, the install hook will fail because the `poetry` plugin only uses the main depenencies section