### PR TITLE
fix: make sure concurrency groups are unique when called by release workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,7 @@
 name: Build charm
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: build-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -4,7 +4,7 @@
 name: Lint charm
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: lint-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -4,7 +4,7 @@
 name: Unit test charm
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: unit-test-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 on:


### PR DESCRIPTION
https://github.com/canonical/landscape-server-operator/actions/runs/21653711516/job/62424073846

The release workflow never runs becuae it depends on the lint, unit test, and build jobs. However, because they're being called by the `release.yaml` workflow, the way the concurrency group is constructed is no longer unique and all except one gets cancelled due to the concurrency rules.

This makes it so even when the workflows are called, the concurrency group is unique and they won't cancel each other