### PR TITLE
fix: revert 'run all GH actions on self-hosted runners' (#91)

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   lint:
     name: Lint
-    runs-on: [self-hosted, noble, amd64]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -26,7 +26,7 @@ jobs:
         run: make check
 
   terraform-check:
-    runs-on: [self-hosted, noble, amd64]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
       - uses: hashicorp/setup-terraform@v3

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -12,16 +12,15 @@ on:
   workflow_call:
 
 jobs:
-  charm-unit-test:
+  unit-test:
     name: Unit test charm
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        series:
-          - jammy
-          - noble
-
-    runs-on: [self-hosted, amd64, "${{ matrix.series }}"]
+        os:
+          - ubuntu-22.04
+          - ubuntu-24.04
     timeout-minutes: 5
     steps:
       - name: Checkout
@@ -32,13 +31,6 @@ jobs:
 
       - name: Run tests
         run: make test
-
-  terraform-unit-test:
-    name: Terraform unit tests
-    runs-on: [self-hosted, amd64, noble]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
 
       - uses: hashicorp/setup-terraform@v3
         with:

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -12,15 +12,16 @@ on:
   workflow_call:
 
 jobs:
-  unit-test:
+  charm-unit-test:
     name: Unit test charm
-    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os:
           - ubuntu-22.04
           - ubuntu-24.04
+
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 5
     steps:
       - name: Checkout
@@ -31,6 +32,13 @@ jobs:
 
       - name: Run tests
         run: make test
+
+  terraform-unit-test:
+    name: Terraform unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
 
       - uses: hashicorp/setup-terraform@v3
         with:


### PR DESCRIPTION
This reverts commit 3427d8c9e58eb4383368a6db65284175251c00f5 / #91 

I'm getting failures: https://github.com/canonical/landscape-server-operator/actions/runs/23861326877/job/69568509124

plus this repo isn't even private so the minutes are free for the GH hosted runners.