### PR TITLE
fix: ignore pgbouncer units in product module

### DIFF
--- a/terraform/product/modules/landscape-scalable/main.tf
+++ b/terraform/product/modules/landscape-scalable/main.tf
@@ -531,7 +531,6 @@ resource "juju_integration" "haproxy_receive_ca_certs" {
 resource "juju_application" "pgbouncer" {
   name       = var.pgbouncer.app_name
   model_uuid = var.model_uuid
-  units      = 0
   config     = var.pgbouncer.config
 
   charm {
@@ -539,6 +538,11 @@ resource "juju_application" "pgbouncer" {
     revision = var.pgbouncer.revision
     channel  = var.pgbouncer.channel
     base     = var.pgbouncer.base
+  }
+
+  lifecycle {
+    # It's a subordinate
+    ignore_changes = [units]
   }
 
   count = var.pgbouncer != null && local.has_modern_pg_interface ? 1 : 0


### PR DESCRIPTION
I get a Juju TF provider error because it tries to change it from 0 to 1... Note sure how I missed this