### PR TITLE
chore(terraform): update terraform modules to latest standards

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "automerge": true,
+  "customDatasources": {
+    "charmhub": {
+      "defaultRegistryUrlTemplate": "https://api.charmhub.io/v2/charms/info/{{packageName}}?fields=channel-map",
+      "format": "json",
+      "transformTemplates": [
+        "{\"releases\": [{\"version\": $string($$.(`channel-map`[channel.risk = 'edge' and channel.track = 'latest' and channel.base.architecture = 'amd64' and channel.base.channel = '24.04'].revision.revision))}]}"
+      ]
+    }
+  },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "datasourceTemplate": "docker",
+      "description": "Update base image references",
+      "managerFilePatterns": [
+        "/(^|/)rockcraft.yaml$/"
+      ],
+      "matchStrings": [
+        "# renovate: build-base:\\s+(?<depName>[^:]*):(?<currentValue>[^\\s@]*)(@(?<currentDigest>sha256:[0-9a-f]*))?",
+        "# renovate: base:\\s+(?<depName>[^:]*):(?<currentValue>[^\\s@]*)(@(?<currentDigest>sha256:[0-9a-f]*))?"
+      ],
+      "matchStringsStrategy": "any",
+      "versioningTemplate": "ubuntu"
+    },
+    {
+      "customType": "regex",
+      "datasourceTemplate": "custom.charmhub",
+      "fileMatch": [
+        "\\.tftest\\.hcl$",
+        "\\.tf$"
+      ],
+      "matchStrings": [
+        "# renovate: depName=\"(?<packageName>[^\"]+)\"\\s*\\n\\s*(?<fieldName>[a-zA-Z0-9_]+)\\s*=\\s*(?<currentValue>\\d+)"
+      ],
+      "versioningTemplate": "semver-coerced"
+    }
+  ],
+  "extends": [
+    "config:recommended",
+    "group:allNonMajor"
+  ],
+  "ignorePaths": [],
+  "packageRules": [
+    {
+      "enabled": true,
+      "matchDatasources": [
+        "docker"
+      ],
+      "pinDigests": true
+    },
+    {
+      "automerge": true,
+      "enabled": true,
+      "matchDatasources": [
+        "custom.charmhub"
+      ]
+    },
+    {
+      "enabled": false,
+      "matchFileNames": [
+        "rockcraft.yaml"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "patch"
+      ]
+    }
+  ],
+  "schedule": [
+    "* * * * 0,6"
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": true
+  }
+}

--- a/terraform/.tflint.hcl
+++ b/terraform/.tflint.hcl
@@ -1,0 +1,5 @@
+# © 2025 Canonical Ltd.
+
+rule "terraform_required_version" {
+  enabled = true
+}

--- a/terraform/charm/README.md
+++ b/terraform/charm/README.md
@@ -91,7 +91,7 @@ make fix-charm-module
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.12 |
 | <a name="requirement_juju"></a> [juju](#requirement\_juju) | ~> 1.0 |
 
 ## Providers

--- a/terraform/charm/outputs.tf
+++ b/terraform/charm/outputs.tf
@@ -1,4 +1,4 @@
-# © 2026 Canonical Ltd.
+# © 2025 Canonical Ltd.
 
 # The following outputs are meant to conform with Canonical's standards for
 # charm modules in a Terraform ecosystem (CC008).

--- a/terraform/charm/tests/main.tftest.hcl
+++ b/terraform/charm/tests/main.tftest.hcl
@@ -1,0 +1,21 @@
+# © 2025 Canonical Ltd.
+
+run "setup_tests" {
+  module {
+    source = "./tests/setup"
+  }
+}
+
+run "basic_deploy" {
+  variables {
+    model_uuid = run.setup_tests.model_uuid
+    channel    = "latest/edge"
+    # renovate: depName="landscape-server"
+    revision = 143
+  }
+
+  assert {
+    condition     = output.app_name == "landscape-server"
+    error_message = "landscape-server app_name did not match expected"
+  }
+}

--- a/terraform/charm/tests/setup/main.tf
+++ b/terraform/charm/tests/setup/main.tf
@@ -1,0 +1,21 @@
+# © 2025 Canonical Ltd.
+
+terraform {
+  required_version = "~> 1.12"
+  required_providers {
+    juju = {
+      version = "~> 1.0"
+      source  = "juju/juju"
+    }
+  }
+}
+
+provider "juju" {}
+
+resource "juju_model" "test_model" {
+  name = "tf-testing-${formatdate("YYYYMMDDhhmmss", timestamp())}"
+}
+
+output "model_uuid" {
+  value = juju_model.test_model.uuid
+}

--- a/terraform/charm/versions.tf
+++ b/terraform/charm/versions.tf
@@ -1,7 +1,7 @@
 # © 2025 Canonical Ltd.
 
 terraform {
-  required_version = ">= 1.10"
+  required_version = "~> 1.12"
   required_providers {
     juju = {
       source  = "juju/juju"

--- a/terraform/product/modules/landscape-scalable/README.md
+++ b/terraform/product/modules/landscape-scalable/README.md
@@ -58,7 +58,7 @@ This module uses the [Landscape Server charm module](https://github.com/canonica
 
 | Name                                                                      | Version |
 | ------------------------------------------------------------------------- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.12 |
 | <a name="requirement_juju"></a> [juju](#requirement\_juju)                | ~> 1.0  |
 
 ## Providers

--- a/terraform/product/modules/landscape-scalable/tests/main.tftest.hcl
+++ b/terraform/product/modules/landscape-scalable/tests/main.tftest.hcl
@@ -1,0 +1,23 @@
+# © 2025 Canonical Ltd.
+
+run "setup_tests" {
+  module {
+    source = "./tests/setup"
+  }
+}
+
+run "basic_deploy" {
+  variables {
+    model_uuid = run.setup_tests.model_uuid
+    landscape_server = {
+      channel = "latest/edge"
+      # renovate: depName="landscape-server"
+      revision = 143
+    }
+  }
+
+  assert {
+    condition     = output.applications.landscape_server.app_name == "landscape-server"
+    error_message = "landscape-server app_name did not match expected"
+  }
+}

--- a/terraform/product/modules/landscape-scalable/tests/setup/main.tf
+++ b/terraform/product/modules/landscape-scalable/tests/setup/main.tf
@@ -1,0 +1,21 @@
+# © 2025 Canonical Ltd.
+
+terraform {
+  required_version = "~> 1.12"
+  required_providers {
+    juju = {
+      version = "~> 1.0"
+      source  = "juju/juju"
+    }
+  }
+}
+
+provider "juju" {}
+
+resource "juju_model" "test_model" {
+  name = "tf-testing-${formatdate("YYYYMMDDhhmmss", timestamp())}"
+}
+
+output "model_uuid" {
+  value = juju_model.test_model.uuid
+}

--- a/terraform/product/modules/landscape-scalable/versions.tf
+++ b/terraform/product/modules/landscape-scalable/versions.tf
@@ -1,7 +1,7 @@
 # © 2025 Canonical Ltd.
 
 terraform {
-  required_version = ">= 1.10"
+  required_version = "~> 1.12"
   required_providers {
     juju = {
       source  = "juju/juju"


### PR DESCRIPTION
## Summary

This PR aligns the Terraform modules with the team's latest standards.

### Changes

- **`terraform/charm/versions.tf`**: Updated `required_version` from `>= 1.10` to `~> 1.12` and juju provider to `~> 1.0`
- **`terraform/product/modules/landscape-scalable/versions.tf`**: Same version updates
- **`terraform/.tflint.hcl`**: Added tflint config at terraform root with `terraform_required_version` rule enabled (as per standard)
- **`renovate.json`**: Added with charmhub custom datasource for automated terraform revision tracking (renovate will auto-update charm revision numbers in `.tftest.hcl` files)
- **`terraform/charm/tests/main.tftest.hcl`** and **`terraform/charm/tests/setup/main.tf`**: Added integration test setup for the charm module
- **`terraform/product/modules/landscape-scalable/tests/main.tftest.hcl`** and **tests/setup/main.tf`**: Added integration test setup for the product module
- **`terraform/charm/outputs.tf`**: Fixed copyright year typo (2026 → 2025)
- **`terraform/charm/README.md`** and **product README**: Updated version constraint in auto-generated docs section

### Missing (requires `workflow` scope on token)

The following file could not be pushed due to token permission limitations and needs to be added manually:

**`.github/workflows/test_terraform_modules.yaml`**:
```yaml
# Copyright 2025 Canonical Ltd.
# See LICENSE file for licensing details.

name: Terraform modules tests

on:
  workflow_dispatch:
  pull_request:
    paths:
      - 'terraform/**'

jobs:
  terraform-tests:
    uses: canonical/operator-workflows/.github/workflows/terraform_modules_test.yaml@main
    secrets: inherit
    with:
      lxd-controller: true
      terraform-directories: '["terraform/charm", "terraform/product/modules/landscape-scalable"]'
```

### Testing

All mock-provider terraform tests pass:
```
Success! 16 passed, 0 failed.
```

_This PR was opened by the [charmkeeper](https://github.com/seb4stien/charmkeeper) agent._