### PR TITLE
feat: default to latest/stable for outbox channel

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -270,7 +270,7 @@ options:
       Port for ubuntu-installer-attach service worker to use on each unit.
   outbox_snap_channel:
     type: string
-    default: latest/edge
+    default: 1/stable
     description: |
       Snap channel from which to install the landscape-outbox snap.
       Changing this value will refresh the installed snap to the

--- a/config.yaml
+++ b/config.yaml
@@ -270,7 +270,7 @@ options:
       Port for ubuntu-installer-attach service worker to use on each unit.
   outbox_snap_channel:
     type: string
-    default: 1/stable
+    default: latest/stable
     description: |
       Snap channel from which to install the landscape-outbox snap.
       Changing this value will refresh the installed snap to the

--- a/src/charm.py
+++ b/src/charm.py
@@ -108,7 +108,7 @@ LANDSCAPE_PACKAGES = (
     "landscape-common",
 )
 LANDSCAPE_OUTBOX_SNAP = "landscape-outbox"
-DEFAULT_OUTBOX_SNAP_CHANNEL = "latest/edge"  # TODO update when stable is released.
+DEFAULT_OUTBOX_SNAP_CHANNEL = "1/stable"
 LANDSCAPE_UBUNTU_INSTALLER_ATTACH = "landscape-ubuntu-installer-attach"
 
 DEFAULT_SERVICES = (

--- a/src/charm.py
+++ b/src/charm.py
@@ -108,7 +108,7 @@ LANDSCAPE_PACKAGES = (
     "landscape-common",
 )
 LANDSCAPE_OUTBOX_SNAP = "landscape-outbox"
-DEFAULT_OUTBOX_SNAP_CHANNEL = "1/stable"
+DEFAULT_OUTBOX_SNAP_CHANNEL = "latest/stable"
 LANDSCAPE_UBUNTU_INSTALLER_ATTACH = "landscape-ubuntu-installer-attach"
 
 DEFAULT_SERVICES = (


### PR DESCRIPTION
Use the stable release of outbox 1.0.0 as the default channel.