### PR TITLE
ci: create release.yaml

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,0 +1,8 @@
+changelog:
+  categories:
+    - title: Features
+      labels:
+        - enhancement
+    - title: Bug fixes
+      labels:
+        - bug


### PR DESCRIPTION
https://github.com/canonical/postgresql-operator/blob/main/.github/release.yaml

Turns out it is needed: https://github.com/canonical/landscape-server-operator/actions/runs/25508631901/job/74861085350