### PR TITLE
fix: additional_service_config worker count takes precendence over worker_counts

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -465,21 +465,6 @@ class LandscapeServerCharm(CharmBase):
         configure_for_deployment_mode(self.charm_config.deployment_mode)
         write_deployment_mode_systemd_override(self.charm_config.deployment_mode)
 
-        if self.charm_config.additional_service_config:
-            merge_service_conf(self.charm_config.additional_service_config)
-
-        if self.charm_config.license_file:
-            self.unit.status = MaintenanceStatus("Writing Landscape license file")
-            write_license_file(
-                self.charm_config.license_file,
-                user_exists("landscape").pw_uid,
-                self.root_gid,
-            )
-            self.unit.status = WaitingStatus("Waiting on relations")
-
-        self._configure_openid()
-        self._configure_oidc()
-
         service_conf_updates = {
             service: {"workers": str(self.charm_config.worker_counts)}
             for service in ("landscape", "api", "message-server", "pingserver")
@@ -511,6 +496,21 @@ class LandscapeServerCharm(CharmBase):
         }
 
         update_service_conf(service_conf_updates)
+
+        if self.charm_config.additional_service_config:
+            merge_service_conf(self.charm_config.additional_service_config)
+
+        if self.charm_config.license_file:
+            self.unit.status = MaintenanceStatus("Writing Landscape license file")
+            write_license_file(
+                self.charm_config.license_file,
+                user_exists("landscape").pw_uid,
+                self.root_gid,
+            )
+            self.unit.status = WaitingStatus("Waiting on relations")
+
+        self._configure_openid()
+        self._configure_oidc()
 
         db_kargs = {}
         if config_host := self.charm_config.db_host:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -175,6 +175,38 @@ class TestOnConfigChanged:
         assert config["message-server"]["workers"] == str(workers)
         assert config["pingserver"]["workers"] == str(workers)
 
+    def test_additional_service_config_overrides_worker_counts(self, capture_service_conf):
+        """
+        If `additional_service_config` specifies worker counts, it takes priority
+        over the `worker_counts` config setting.
+        """
+        additional_config = """
+[landscape]
+workers = 5
+
+[api]
+workers = 7
+
+[message-server]
+workers = 3
+
+[pingserver]
+workers = 4
+"""
+        context = Context(LandscapeServerCharm)
+        state = State(config={
+            "worker_counts": 10,
+            "additional_service_config": additional_config
+        })
+        context.run(context.on.config_changed(), state)
+
+        config = capture_service_conf.get_config()
+
+        assert config["landscape"]["workers"] == "5"
+        assert config["api"]["workers"] == "7"
+        assert config["message-server"]["workers"] == "3"
+        assert config["pingserver"]["workers"] == "4"
+
     def test_hostagent_services_default(
         self,
         replicas_network_state,

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -209,6 +209,86 @@ workers = 4
         assert config["message-server"]["workers"] == "3"
         assert config["pingserver"]["workers"] == "4"
 
+    def test_additional_service_config_overrides_base_ports(self, capture_service_conf):
+        """
+        `additional_service_config` takes priority over all base_port config options.
+        """
+        additional_config = """
+[landscape]
+base_port = 1111
+
+[api]
+base_port = 2222
+
+[message-server]
+base_port = 3333
+
+[pingserver]
+base_port = 4444
+
+[package-upload]
+base_port = 5555
+
+[hostagent-message-server]
+base_port = 6666
+
+[ubuntu-installer-attach]
+base_port = 7777
+"""
+        context = Context(LandscapeServerCharm)
+        state = State(
+            config={
+                "appserver_base_port": 8080,
+                "api_base_port": 9080,
+                "message_server_base_port": 8090,
+                "pingserver_base_port": 8070,
+                "package_upload_base_port": 9100,
+                "hostagent_server_base_port": 50052,
+                "ubuntu_installer_attach_base_port": 53354,
+                "additional_service_config": additional_config,
+            }
+        )
+        context.run(context.on.config_changed(), state)
+
+        config = capture_service_conf.get_config()
+
+        assert config["landscape"]["base_port"] == "1111"
+        assert config["api"]["base_port"] == "2222"
+        assert config["message-server"]["base_port"] == "3333"
+        assert config["pingserver"]["base_port"] == "4444"
+        assert config["package-upload"]["base_port"] == "5555"
+        assert config["hostagent-message-server"]["base_port"] == "6666"
+        assert config["ubuntu-installer-attach"]["base_port"] == "7777"
+
+    def test_additional_service_config_overrides_root_url(self, capture_service_conf):
+        """
+        `additional_service_config` takes priority over the `root_url` config option.
+        """
+        additional_config = """
+[global]
+root-url = https://overridden.example.com
+
+[api]
+root-url = https://overridden.example.com
+
+[package-upload]
+root-url = https://overridden.example.com
+"""
+        context = Context(LandscapeServerCharm)
+        state = State(
+            config={
+                "root_url": "https://original.example.com",
+                "additional_service_config": additional_config,
+            }
+        )
+        context.run(context.on.config_changed(), state)
+
+        config = capture_service_conf.get_config()
+
+        assert config["global"]["root-url"] == "https://overridden.example.com"
+        assert config["api"]["root-url"] == "https://overridden.example.com"
+        assert config["package-upload"]["root-url"] == "https://overridden.example.com"
+
     def test_hostagent_services_default(
         self,
         replicas_network_state,

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -175,7 +175,10 @@ class TestOnConfigChanged:
         assert config["message-server"]["workers"] == str(workers)
         assert config["pingserver"]["workers"] == str(workers)
 
-    def test_additional_service_config_overrides_worker_counts(self, capture_service_conf):
+    def test_additional_service_config_overrides_worker_counts(
+        self,
+        capture_service_conf,
+    ):
         """
         If `additional_service_config` specifies worker counts, it takes priority
         over the `worker_counts` config setting.
@@ -194,10 +197,9 @@ workers = 3
 workers = 4
 """
         context = Context(LandscapeServerCharm)
-        state = State(config={
-            "worker_counts": 10,
-            "additional_service_config": additional_config
-        })
+        state = State(
+            config={"worker_counts": 10, "additional_service_config": additional_config}
+        )
         context.run(context.on.config_changed(), state)
 
         config = capture_service_conf.get_config()


### PR DESCRIPTION
This pull request refactors the order of configuration updates in the `config_changed` handler to ensure that service configuration overrides are applied correctly, and adds a new unit test to verify that `additional_service_config` takes precedence over the `worker_counts` setting.

You can test it by deploying the charms, then updating the config like so:

my-config.yaml
```yaml
landscape-server:
  worker_counts: 9
  additional_service_config: |
    [pingserver]
    workers = 7
```

Then if you SSH to the landscape-server unit, you should be able to use `systemctl status` to see that `landscape-pingserver` has 7 workers, yet the other twisted services have 9.

This was not possible before this change.