### PR TITLE
ci: add read perms to build.yaml

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,6 +16,10 @@ on:
         value: ${{ jobs.build.outputs.artifact-prefix }}
   workflow_dispatch:
 
+permissions:
+  actions: read
+  contents: read
+
 jobs:
   build:
     name: Build charm


### PR DESCRIPTION
These are required for the workflow to run: https://github.com/canonical/data-platform-workflows/blob/v49.0.1/.github/workflows/build_charm.yaml#L201