### PR TITLE
feat: add demo data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,14 +52,14 @@ deploy:
 	@if [ "$(SKIP_CLEAN)" != "true" ]; then $(MAKE) clean; else echo "skipping clean..."; fi
 	@if [ "$(SKIP_BUILD)" != "true" ]; then $(MAKE) build; else echo "skipping build..."; fi
 	$(MAKE) add-model
-	juju deploy -m $(MODEL_NAME) $(BUNDLE_DEPLOY_PATH)
+	juju deploy -m $(MODEL_NAME) $(BUNDLE_PATH)
 
 .PHONY: deploy-lbaas
 deploy-lbaas:
 	@if [ "$(SKIP_CLEAN)" != "true" ]; then $(MAKE) clean; else echo "skipping clean..."; fi
 	@if [ "$(SKIP_BUILD)" != "true" ]; then $(MAKE) build; else echo "skipping build..."; fi
 	$(MAKE) add-model
-	juju deploy -m $(MODEL_NAME) $(LBAAS_BUNDLE_DEPLOY_PATH)
+	juju deploy -m $(MODEL_NAME) $(LBAAS_BUNDLE_PATH)
 
 .PHONY: check-jq
 check-jq:

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,10 @@ SKIP_BUILD ?= false
 SKIP_CLEAN ?= false
 SKIP_ADD_MODEL ?= false
 
+# juju deploy treats a bare "foo/bar.yaml" as ambiguous; force local interpretation.
+BUNDLE_DEPLOY_PATH := $(if $(filter /% ./%,$(BUNDLE_PATH)),$(BUNDLE_PATH),./$(BUNDLE_PATH))
+LBAAS_BUNDLE_DEPLOY_PATH := $(if $(filter /% ./%,$(LBAAS_BUNDLE_PATH)),$(LBAAS_BUNDLE_PATH),./$(LBAAS_BUNDLE_PATH))
+
 # Python testing and linting
 .PHONY: test
 test:
@@ -52,14 +56,14 @@ deploy:
 	@if [ "$(SKIP_CLEAN)" != "true" ]; then $(MAKE) clean; else echo "skipping clean..."; fi
 	@if [ "$(SKIP_BUILD)" != "true" ]; then $(MAKE) build; else echo "skipping build..."; fi
 	$(MAKE) add-model
-	juju deploy -m $(MODEL_NAME) $(BUNDLE_PATH)
+	juju deploy -m $(MODEL_NAME) $(BUNDLE_DEPLOY_PATH)
 
 .PHONY: deploy-lbaas
 deploy-lbaas:
 	@if [ "$(SKIP_CLEAN)" != "true" ]; then $(MAKE) clean; else echo "skipping clean..."; fi
 	@if [ "$(SKIP_BUILD)" != "true" ]; then $(MAKE) build; else echo "skipping build..."; fi
 	$(MAKE) add-model
-	juju deploy -m $(MODEL_NAME) $(LBAAS_BUNDLE_PATH)
+	juju deploy -m $(MODEL_NAME) $(LBAAS_BUNDLE_DEPLOY_PATH)
 
 .PHONY: check-jq
 check-jq:

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,6 @@ SKIP_BUILD ?= false
 SKIP_CLEAN ?= false
 SKIP_ADD_MODEL ?= false
 
-# juju deploy treats a bare "foo/bar.yaml" as ambiguous; force local interpretation.
-BUNDLE_DEPLOY_PATH := $(if $(filter /% ./%,$(BUNDLE_PATH)),$(BUNDLE_PATH),./$(BUNDLE_PATH))
-LBAAS_BUNDLE_DEPLOY_PATH := $(if $(filter /% ./%,$(LBAAS_BUNDLE_PATH)),$(LBAAS_BUNDLE_PATH),./$(LBAAS_BUNDLE_PATH))
-
 # Python testing and linting
 .PHONY: test
 test:

--- a/bundle-examples/bundle.yaml
+++ b/bundle-examples/bundle.yaml
@@ -27,6 +27,7 @@ applications:
       enable_hostagent_messenger: True
       enable_ubuntu_installer_attach: True
       root_url: https://landscape.local/
+      demo_data: True
     base: ubuntu@24.04
   haproxy:
     charm: ch:haproxy

--- a/bundle-examples/bundle.yaml
+++ b/bundle-examples/bundle.yaml
@@ -1,4 +1,4 @@
-description: Landscape Scalable Dev with in-model HAProxy
+description: Landscape Scalable Dev in SaaS (non-self-hosted) mode
 applications:
   postgresql:
     channel: 16/stable
@@ -48,5 +48,8 @@ relations:
   - [landscape-server:package-upload-haproxy-route, haproxy:haproxy-route]
   - [landscape-server:repository-haproxy-route, haproxy:haproxy-route]
   - [landscape-server:hostagent-messenger-haproxy-route, haproxy:haproxy-route]
-  - [landscape-server:ubuntu-installer-attach-haproxy-route, haproxy:haproxy-route]
+  - [
+      landscape-server:ubuntu-installer-attach-haproxy-route,
+      haproxy:haproxy-route,
+    ]
   - [landscape-server:appserver-haproxy-route, haproxy:haproxy-route]

--- a/bundle-examples/bundle.yaml
+++ b/bundle-examples/bundle.yaml
@@ -22,12 +22,23 @@ applications:
     charm: ../landscape-server_ubuntu@24.04-amd64.charm
     num_units: 1
     options:
-      landscape_ppa: "ppa:landscape/self-hosted-beta"
-      min_install: True
-      enable_hostagent_messenger: True
-      enable_ubuntu_installer_attach: True
+      deployment_mode: staging
+      demo_data: true
       root_url: https://landscape.local/
-      demo_data: True
+      additional_service_config: |
+        [stores]
+        main = landscape-staging-main
+        account-1 = landscape-staging-account-1
+        resource-1 = landscape-staging-resource-1
+        package = landscape-staging-package
+        session = landscape-staging-session
+        session-autocommit = landscape-staging-session?isolation=autocommit
+        [api]
+        stores = main account-1 resource-1 package session session-autocommit
+        [system]
+        enable_subdomain_accounts = true
+        [features]
+        self_service_account_creation = true
     base: ubuntu@24.04
   haproxy:
     charm: ch:haproxy

--- a/bundle-examples/bundle.yaml
+++ b/bundle-examples/bundle.yaml
@@ -1,4 +1,4 @@
-description: Landscape Scalable Dev in SaaS (non-self-hosted) mode
+description: Landscape Scalable Dev with in-model HAProxy
 applications:
   postgresql:
     channel: 16/stable
@@ -22,8 +22,12 @@ applications:
     charm: ../landscape-server_ubuntu@24.04-amd64.charm
     num_units: 1
     options:
-      demo_data: True
+      landscape_ppa: "ppa:landscape/self-hosted-beta"
+      min_install: True
+      enable_hostagent_messenger: True
+      enable_ubuntu_installer_attach: True
       root_url: https://landscape.local/
+      demo_data: True
     base: ubuntu@24.04
   haproxy:
     charm: ch:haproxy

--- a/bundle-examples/saas.bundle.yaml
+++ b/bundle-examples/saas.bundle.yaml
@@ -1,4 +1,4 @@
-description: Landscape Scalable Dev with in-model HAProxy
+description: Landscape Scalable Dev in SaaS (non-self-hosted) mode
 applications:
   postgresql:
     channel: 16/stable
@@ -63,5 +63,8 @@ relations:
   - [landscape-server:package-upload-haproxy-route, haproxy:haproxy-route]
   - [landscape-server:repository-haproxy-route, haproxy:haproxy-route]
   - [landscape-server:hostagent-messenger-haproxy-route, haproxy:haproxy-route]
-  - [landscape-server:ubuntu-installer-attach-haproxy-route, haproxy:haproxy-route]
+  - [
+      landscape-server:ubuntu-installer-attach-haproxy-route,
+      haproxy:haproxy-route,
+    ]
   - [landscape-server:appserver-haproxy-route, haproxy:haproxy-route]

--- a/bundle-examples/saas.bundle.yaml
+++ b/bundle-examples/saas.bundle.yaml
@@ -22,8 +22,23 @@ applications:
     charm: ../landscape-server_ubuntu@24.04-amd64.charm
     num_units: 1
     options:
-      demo_data: True
+      deployment_mode: staging
+      demo_data: true
       root_url: https://landscape.local/
+      additional_service_config: |
+        [stores]
+        main = landscape-staging-main
+        account-1 = landscape-staging-account-1
+        resource-1 = landscape-staging-resource-1
+        package = landscape-staging-package
+        session = landscape-staging-session
+        session-autocommit = landscape-staging-session?isolation=autocommit
+        [api]
+        stores = main account-1 resource-1 package session session-autocommit
+        [system]
+        enable_subdomain_accounts = true
+        [features]
+        self_service_account_creation = true
     base: ubuntu@24.04
   haproxy:
     charm: ch:haproxy

--- a/config.yaml
+++ b/config.yaml
@@ -293,3 +293,9 @@ options:
     default: false
     description: |
       Whether to create demo data when running the schema migration.
+  bootstrap_schema_override_args:
+    type: string
+    default:
+    description: |
+      Comma-separated extra arguments to append to `landscape-schema --bootstrap`.
+      Example: --with-extra-computers,10,--with-openstack

--- a/config.yaml
+++ b/config.yaml
@@ -288,3 +288,8 @@ options:
       Snap channel from which to install the landscape-outbox snap.
       Changing this value will refresh the installed snap to the
       specified channel.
+  demo_data:
+    type: boolean
+    default: false
+    description: |
+      Whether to create demo data when running the schema migration.

--- a/src/charm.py
+++ b/src/charm.py
@@ -153,6 +153,49 @@ PROXY_ENV_MAPPING = {
     "JUJU_CHARM_NO_PROXY": "--with-no-proxy",
 }
 
+DEMO_SCHEMA_ARGS_SAAS = [
+    "--with-computers",
+    "--with-free-disk-space",
+    "--with-free-memory-and-swap",
+    "--with-load-averages",
+    "--with-temperatures",
+    "--with-network-traffic",
+    "--with-active-processes",
+    "--with-hardware",
+    "--with-packages",
+    "--with-package-activities",
+    "--with-script-activities",
+    "--with-users-and-groups",
+    "--with-cpu-usage",
+    "--with-ceph-usage",
+    "--with-compute-usage",
+    "--with-swift-usage",
+    "--with-user-and-group-activities",
+    "--with-custom-graph",
+    "--with-scripts",
+]
+
+DEMO_SCHEMA_ARGS_STANDALONE = [
+    "--with-computers",
+    "--with-free-disk-space",
+    "--with-free-memory-and-swap",
+    "--with-load-averages",
+    "--with-temperatures",
+    "--with-network-traffic",
+    "--with-active-processes",
+    "--with-packages",
+    "--with-package-activities",
+    "--with-script-activities",
+    "--with-users-and-groups",
+    "--with-cpu-usage",
+    "--with-ceph-usage",
+    "--with-compute-usage",
+    "--with-swift-usage",
+    "--with-user-and-group-activities",
+    "--with-custom-graph",
+    "--with-scripts",
+]
+
 METRIC_INSTRUMENTED_SERVICE_PORTS = [
     ("appserver", 8080),
     ("pingserver", 8070),
@@ -531,6 +574,9 @@ class LandscapeServerCharm(CharmBase):
         if db_kwargs:
             update_db_conf(**db_kwargs)
             if self._migrate_schema_bootstrap(demo_data=demo_data):
+                if demo_data and self.charm_config.deployment_mode == "standalone":
+                    if not self._update_wsl_distributions():
+                        return
                 self.unit.status = WaitingStatus("Waiting on relations")
                 self._stored.ready["db"] = True
             else:
@@ -956,7 +1002,7 @@ class LandscapeServerCharm(CharmBase):
             schema_password=schema_password,
         )
 
-        if not self._migrate_schema_bootstrap():
+        if not self._migrate_schema_bootstrap(demo_data=self.charm_config.demo_data):
             return
 
         if not self._update_wsl_distributions():
@@ -1049,7 +1095,9 @@ class LandscapeServerCharm(CharmBase):
 
         roles = get_postgres_roles(db_ctx.version)
 
-        if not self._migrate_schema_bootstrap(roles.owner):
+        if not self._migrate_schema_bootstrap(
+            roles.owner, demo_data=self.charm_config.demo_data
+        ):
             logger.error(
                 "Migrating schema failed trying to update the `database` relation!"
             )
@@ -1131,30 +1179,9 @@ class LandscapeServerCharm(CharmBase):
             call.extend(self._proxy_settings)
 
         if demo_data:
-            call.extend(
-                [
-                    "--with-computers",
-                    "--with-free-disk-space",
-                    "--with-free-memory-and-swap",
-                    "--with-load-averages",
-                    "--with-temperatures",
-                    "--with-network-traffic",
-                    "--with-active-processes",
-                    "--with-packages",
-                    "--with-package-activities",
-                    "--with-script-activities",
-                    "--with-users-and-groups",
-                    "--with-cpu-usage",
-                    "--with-ceph-usage",
-                    "--with-compute-usage",
-                    "--with-swift-usage",
-                    "--with-user-and-group-activities",
-                    "--with-custom-graph",
-                    "--with-scripts",
-                    "--with-account-password",
-                    "foo",
-                ]
-            )
+            call.extend(self._demo_schema_args())
+
+        call.extend(self.charm_config.bootstrap_schema_override_args_list)
 
         try:
             check_call(call, env=get_modified_env_vars())
@@ -1169,6 +1196,19 @@ class LandscapeServerCharm(CharmBase):
         self._bootstrap_account()
         self._set_autoregistration()
         return True
+
+    def _demo_schema_args(self) -> list[str]:
+        if self.charm_config.deployment_mode == "standalone":
+            args = DEMO_SCHEMA_ARGS_STANDALONE.copy()
+            account_password = self.charm_config.registration_key or "foo"
+            args.extend(["--with-account-password", account_password])
+            if self.charm_config.root_url:
+                args.extend(["--with-root-url", self.charm_config.root_url])
+            if self.charm_config.system_email:
+                args.extend(["--with-system-email", self.charm_config.system_email])
+            return args
+
+        return DEMO_SCHEMA_ARGS_SAAS.copy()
 
     def _update_wsl_distributions(self) -> bool | None:
         logger.info("Updating WSL distributions...")

--- a/src/charm.py
+++ b/src/charm.py
@@ -512,20 +512,25 @@ class LandscapeServerCharm(CharmBase):
         self._configure_openid()
         self._configure_oidc()
 
-        db_kargs = {}
+        db_kwargs = {}
+        demo_data = False
         if config_host := self.charm_config.db_host:
-            db_kargs["host"] = config_host
+            db_kwargs["host"] = config_host
         if schema_password := self.charm_config.db_schema_password:
-            db_kargs["schema_password"] = schema_password
+            db_kwargs["schema_password"] = schema_password
         if config_port := self.charm_config.db_port:
-            db_kargs["port"] = config_port
+            db_kwargs["port"] = config_port
         if config_user := self.charm_config.db_schema_user:
-            db_kargs["user"] = config_user
+            db_kwargs["user"] = config_user
         if landscape_password := self.charm_config.db_landscape_password:
-            db_kargs["password"] = landscape_password
-        if db_kargs:
-            update_db_conf(**db_kargs)
-            if self._migrate_schema_bootstrap():
+            db_kwargs["password"] = landscape_password
+
+        if self.charm_config.demo_data:
+            demo_data = True
+
+        if db_kwargs:
+            update_db_conf(**db_kwargs)
+            if self._migrate_schema_bootstrap(demo_data=demo_data):
                 self.unit.status = WaitingStatus("Waiting on relations")
                 self._stored.ready["db"] = True
             else:
@@ -1104,11 +1109,16 @@ class LandscapeServerCharm(CharmBase):
 
         return settings
 
-    def _migrate_schema_bootstrap(self, owner_role: str | None = None):
+    def _migrate_schema_bootstrap(
+        self, owner_role: str | None = None, demo_data: bool = False
+    ):
         """
         Migrates schema along with the bootstrap command which ensures that the
         databases and the landscape user exists, and that proxy settings are set.
-        In addition, creates admin if configured.
+        In addition, creates admin and demo data if configured.
+
+        :param owner_role: The Postgres role to own the database.
+        :param demo_data: Create demo data.
 
         :returns: True on success.
         """
@@ -1119,6 +1129,32 @@ class LandscapeServerCharm(CharmBase):
 
         if self._proxy_settings:
             call.extend(self._proxy_settings)
+
+        if demo_data:
+            call.extend(
+                [
+                    "--with-computers",
+                    "--with-free-disk-space",
+                    "--with-free-memory-and-swap",
+                    "--with-load-averages",
+                    "--with-temperatures",
+                    "--with-network-traffic",
+                    "--with-active-processes",
+                    "--with-packages",
+                    "--with-package-activities",
+                    "--with-script-activities",
+                    "--with-users-and-groups",
+                    "--with-cpu-usage",
+                    "--with-ceph-usage",
+                    "--with-compute-usage",
+                    "--with-swift-usage",
+                    "--with-user-and-group-activities",
+                    "--with-custom-graph",
+                    "--with-scripts",
+                    "--with-account-password",
+                    "foo",
+                ]
+            )
 
         try:
             check_call(call, env=get_modified_env_vars())

--- a/src/charm.py
+++ b/src/charm.py
@@ -153,7 +153,7 @@ PROXY_ENV_MAPPING = {
     "JUJU_CHARM_NO_PROXY": "--with-no-proxy",
 }
 
-DEMO_SCHEMA_ARGS_SAAS = [
+DEMO_SCHEMA_ARGS = [
     "--with-computers",
     "--with-free-disk-space",
     "--with-free-memory-and-swap",
@@ -162,27 +162,6 @@ DEMO_SCHEMA_ARGS_SAAS = [
     "--with-network-traffic",
     "--with-active-processes",
     "--with-hardware",
-    "--with-packages",
-    "--with-package-activities",
-    "--with-script-activities",
-    "--with-users-and-groups",
-    "--with-cpu-usage",
-    "--with-ceph-usage",
-    "--with-compute-usage",
-    "--with-swift-usage",
-    "--with-user-and-group-activities",
-    "--with-custom-graph",
-    "--with-scripts",
-]
-
-DEMO_SCHEMA_ARGS_STANDALONE = [
-    "--with-computers",
-    "--with-free-disk-space",
-    "--with-free-memory-and-swap",
-    "--with-load-averages",
-    "--with-temperatures",
-    "--with-network-traffic",
-    "--with-active-processes",
     "--with-packages",
     "--with-package-activities",
     "--with-script-activities",
@@ -1198,17 +1177,14 @@ class LandscapeServerCharm(CharmBase):
         return True
 
     def _demo_schema_args(self) -> list[str]:
-        if self.charm_config.deployment_mode == "standalone":
-            args = DEMO_SCHEMA_ARGS_STANDALONE.copy()
-            account_password = self.charm_config.registration_key or "foo"
-            args.extend(["--with-account-password", account_password])
-            if self.charm_config.root_url:
-                args.extend(["--with-root-url", self.charm_config.root_url])
-            if self.charm_config.system_email:
-                args.extend(["--with-system-email", self.charm_config.system_email])
-            return args
-
-        return DEMO_SCHEMA_ARGS_SAAS.copy()
+        args = DEMO_SCHEMA_ARGS.copy()
+        account_password = self.charm_config.registration_key or "foo"
+        args.extend(["--with-account-password", account_password])
+        if self.charm_config.root_url:
+            args.extend(["--with-root-url", self.charm_config.root_url])
+        if self.charm_config.system_email:
+            args.extend(["--with-system-email", self.charm_config.system_email])
+        return args
 
     def _update_wsl_distributions(self) -> bool | None:
         logger.info("Updating WSL distributions...")

--- a/src/config.py
+++ b/src/config.py
@@ -79,6 +79,7 @@ class LandscapeCharmConfiguration(BaseModel):
     hostagent_server_base_port: int
     ubuntu_installer_attach_base_port: int
     outbox_snap_channel: str
+    demo_data: bool = False
 
     @field_validator("deployment_mode")
     @classmethod

--- a/src/config.py
+++ b/src/config.py
@@ -80,6 +80,17 @@ class LandscapeCharmConfiguration(BaseModel):
     ubuntu_installer_attach_base_port: int
     outbox_snap_channel: str
     demo_data: bool = False
+    bootstrap_schema_override_args: str | None = None
+
+    @property
+    def bootstrap_schema_override_args_list(self) -> list[str]:
+        if not self.bootstrap_schema_override_args:
+            return []
+        return [
+            arg.strip()
+            for arg in self.bootstrap_schema_override_args.split(",")
+            if arg.strip()
+        ]
 
     @field_validator("deployment_mode")
     @classmethod

--- a/tests/integration/test_bundle.py
+++ b/tests/integration/test_bundle.py
@@ -7,6 +7,7 @@ NOTE: These tests assume an IPv4 public address for the Landscape Server charm.
 
 import json
 import re
+import shlex
 from urllib.parse import urlparse
 
 import jubilant
@@ -31,6 +32,26 @@ from tests.integration.helpers import (
 )
 
 LIVE_MODEL_SKIP_REASON = "Potentially destructive test skipped on live model."
+
+
+def _query_main_db(juju: jubilant.Juju, sql: str) -> str:
+    """Execute a read-only SQL query against the configured main Landscape DB."""
+    result = juju.run("landscape-server/leader", "get-service-conf")
+    stores = json.loads(result.results["config"])["stores"]
+    host, port = stores["host"].rsplit(":", 1)
+    password, user, dbname = stores["password"], stores["user"], stores["main"]
+
+    ssh_command = (
+        f"PGPASSWORD={shlex.quote(password)} "
+        "psql "
+        f"-h {shlex.quote(host)} "
+        f"-p {shlex.quote(port)} "
+        f"-U {shlex.quote(user)} "
+        f"-d {shlex.quote(dbname)} "
+        f"-tAc {shlex.quote(sql)}"
+    )
+
+    return juju.ssh("landscape-server/leader", ssh_command)
 
 
 def _haproxy_ip(juju: jubilant.Juju, lbaas: jubilant.Juju) -> str:
@@ -266,17 +287,48 @@ def test_bootstrap_account_created_with_modern_database(
 
     juju.wait(jubilant.all_active, timeout=300)
 
-    result = juju.run("landscape-server/leader", "get-service-conf")
-    stores = json.loads(result.results["config"])["stores"]
-    host, port = stores["host"].split(":")
-    password, user, dbname = stores["password"], stores["user"], stores["main"]
-    result = juju.ssh(
-        "landscape-server/leader",
-        f"PGPASSWORD={password} psql -h {host} -p {port} -U {user} -d {dbname}"
-        " -tAc 'SELECT email FROM person;'",
-    )
+    result = _query_main_db(juju, "SELECT email FROM person;")
     assert admin_email in result, (
         f"Admin {admin_email} not found in person table after bootstrap. "
+    )
+
+
+def test_demo_data_created_when_config_enabled(juju: jubilant.Juju, bundle: None):
+    """
+    Non-mutative check: only validate demo data if the option is already enabled.
+    """
+    if not has_modern_pg(juju):
+        pytest.skip("Modern database relation not active")
+
+    if not juju.config("landscape-server").get("demo_data"):
+        pytest.skip("demo_data is not enabled in model config")
+
+    juju.wait(jubilant.all_active, timeout=300)
+
+    result = _query_main_db(juju, "SELECT COUNT(*) FROM computer;")
+    assert int(result.strip()) > 0, "Expected demo computers when demo_data is enabled"
+
+
+def test_demo_data_registration_key_matches_config(juju: jubilant.Juju, bundle: None):
+    """
+    Non-mutative check: only validate registration key parity when already set.
+    """
+    if not has_modern_pg(juju):
+        pytest.skip("Modern database relation not active")
+
+    config = juju.config("landscape-server")
+    if not config.get("demo_data"):
+        pytest.skip("demo_data is not enabled in model config")
+
+    registration_key = config.get("registration_key")
+    if not registration_key:
+        pytest.skip("registration_key is not set in model config")
+
+    juju.wait(jubilant.all_active, timeout=300)
+
+    result = _query_main_db(juju, "SELECT registration_key FROM account LIMIT 1;")
+    assert result.strip() == registration_key, (
+        "Expected account.registration_key to match configured registration_key"
     )
 
 
@@ -355,16 +407,10 @@ def test_landscape_schema_migrated(juju: jubilant.Juju, bundle: None):
     """
     juju.wait(jubilant.all_active, timeout=300)
 
-    result = juju.run("landscape-server/leader", "get-service-conf")
-    stores = json.loads(result.results["config"])["stores"]
-    host, port = stores["host"].split(":")
-    password, user, dbname = stores["password"], stores["user"], stores["main"]
-
-    result = juju.ssh(
-        "landscape-server/leader",
-        f"PGPASSWORD={password} psql -h {host} -p {port} -U {user} -d {dbname}"
-        ' -tAc "SELECT COUNT(*) FROM information_schema.tables'
-        " WHERE table_schema = 'public' AND table_name = 'account';\"",
+    result = _query_main_db(
+        juju,
+        "SELECT COUNT(*) FROM information_schema.tables "
+        "WHERE table_schema = 'public' AND table_name = 'account';",
     ).strip()
 
     assert result == "1", (

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1200,11 +1200,13 @@ class TestCharm(unittest.TestCase):
     ):
         root_url = "https://landscape.local/"
         system_email = "landscape-devel@lists.canonical.com"
-        self.harness.update_config({
-            "deployment_mode": "standalone",
-            "root_url": root_url,
-            "system_email": system_email,
-        })
+        self.harness.update_config(
+            {
+                "deployment_mode": "standalone",
+                "root_url": root_url,
+                "system_email": system_email,
+            }
+        )
 
         with patch("charm.check_call") as check_call_mock:
             result = self.harness.charm._migrate_schema_bootstrap(demo_data=True)
@@ -1234,11 +1236,13 @@ class TestCharm(unittest.TestCase):
 
     @patch("charm.get_modified_env_vars", return_value={"PATH": "/usr/bin"})
     def test_migrate_schema_bootstrap_override_args(self, get_env):
-        self.harness.update_config({
-            "bootstrap_schema_override_args": (
-                "--with-openstack,--with-extra-computers,10"
-            )
-        })
+        self.harness.update_config(
+            {
+                "bootstrap_schema_override_args": (
+                    "--with-openstack,--with-extra-computers,10"
+                )
+            }
+        )
 
         with patch("charm.check_call") as check_call_mock:
             result = self.harness.charm._migrate_schema_bootstrap()
@@ -1370,9 +1374,9 @@ class TestCharm(unittest.TestCase):
     def test_update_ready_status_not_running(self):
         self.harness.charm.unit.status = WaitingStatus()
 
-        self.harness.charm._stored.ready.update({
-            k: True for k in self.harness.charm._stored.ready.keys()
-        })
+        self.harness.charm._stored.ready.update(
+            {k: True for k in self.harness.charm._stored.ready.keys()}
+        )
 
         patches = patch.multiple(
             "charm",
@@ -1394,9 +1398,9 @@ class TestCharm(unittest.TestCase):
     def test_update_ready_status_running(self):
         self.harness.charm.unit.status = WaitingStatus()
 
-        self.harness.charm._stored.ready.update({
-            k: True for k in self.harness.charm._stored.ready.keys()
-        })
+        self.harness.charm._stored.ready.update(
+            {k: True for k in self.harness.charm._stored.ready.keys()}
+        )
         self.harness.charm._stored.running = True
 
         self.harness.charm._update_ready_status()
@@ -1408,9 +1412,9 @@ class TestCharm(unittest.TestCase):
     def test_update_ready_status_called_process_error(self):
         self.harness.charm.unit.status = WaitingStatus()
 
-        self.harness.charm._stored.ready.update({
-            k: True for k in self.harness.charm._stored.ready.keys()
-        })
+        self.harness.charm._stored.ready.update(
+            {k: True for k in self.harness.charm._stored.ready.keys()}
+        )
 
         patches = patch.multiple(
             "charm",
@@ -1479,16 +1483,18 @@ class TestCharm(unittest.TestCase):
         self.assertIsInstance(status, BlockedStatus)
         self.assertFalse(self.harness.charm._stored.ready["db"])
 
-        update_service_conf_mock.assert_called_once_with({
-            "stores": {
-                "host": "1.2.3.4:5678",
-                "password": "testpass",
-            },
-            "schema": {
-                "store_user": "testuser",
-                "store_password": "testpass",
-            },
-        })
+        update_service_conf_mock.assert_called_once_with(
+            {
+                "stores": {
+                    "host": "1.2.3.4:5678",
+                    "password": "testpass",
+                },
+                "schema": {
+                    "store_user": "testuser",
+                    "store_password": "testpass",
+                },
+            }
+        )
 
     @patch("charm.update_service_conf")
     def test_on_manual_db_config_change(self, _):
@@ -1525,11 +1531,13 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(update_service_conf_mock.call_count, 2)
         self.assertEqual(
             update_service_conf_mock.call_args_list[1],
-            call({
-                "stores": {
-                    "host": "hello:world",
-                },
-            }),
+            call(
+                {
+                    "stores": {
+                        "host": "hello:world",
+                    },
+                }
+            ),
         )
 
     @patch("charm.update_service_conf")
@@ -1711,12 +1719,14 @@ class TestCharm(unittest.TestCase):
         self.assertTrue(self.harness.charm._stored.ready["inbound-amqp"])
         self.assertTrue(self.harness.charm._stored.ready["outbound-amqp"])
 
-        mock_update_conf.assert_called_once_with({
-            "broker": {
-                "host": ",".join(hostname),
-                "password": password,
-            },
-        })
+        mock_update_conf.assert_called_once_with(
+            {
+                "broker": {
+                    "host": ",".join(hostname),
+                    "password": password,
+                },
+            }
+        )
 
     def test_amqp_relation_changed_outbound_first(self):
         """
@@ -1753,12 +1763,14 @@ class TestCharm(unittest.TestCase):
         self.assertTrue(self.harness.charm._stored.ready["inbound-amqp"])
         self.assertTrue(self.harness.charm._stored.ready["outbound-amqp"])
 
-        mock_update_conf.assert_called_once_with({
-            "broker": {
-                "host": hostname,
-                "password": password,
-            },
-        })
+        mock_update_conf.assert_called_once_with(
+            {
+                "broker": {
+                    "host": hostname,
+                    "password": password,
+                },
+            }
+        )
 
     def test_configure_smtp_relay_host(self):
         mock_postfix_cf = os.path.join(self.tempdir.name, "my_postfix.cf")
@@ -2144,11 +2156,13 @@ class TestCharm(unittest.TestCase):
             )
 
         self.harness.charm._update_nrpe_checks.assert_called_once()
-        mock_update_conf.assert_called_once_with({
-            "package-search": {
-                "host": "localhost",
-            },
-        })
+        mock_update_conf.assert_called_once_with(
+            {
+                "package-search": {
+                    "host": "localhost",
+                },
+            }
+        )
 
     def test_on_replicas_relation_changed_non_leader(self):
         """
@@ -2168,11 +2182,13 @@ class TestCharm(unittest.TestCase):
             )
 
         self.harness.charm._update_nrpe_checks.assert_called_once()
-        mock_update_conf.assert_called_once_with({
-            "package-search": {
-                "host": "test",
-            },
-        })
+        mock_update_conf.assert_called_once_with(
+            {
+                "package-search": {
+                    "host": "test",
+                },
+            }
+        )
 
 
 class TestMultiplePPAs:
@@ -2281,10 +2297,12 @@ class TestBootstrapAccount(unittest.TestCase):
 
     @patch("charm.update_service_conf")
     def test_bootstrap_account_doesnt_run_with_missing_configs(self, _):
-        self.harness.update_config({
-            "admin_email": "hello@ubuntu.com",
-            "admin_name": "Hello Ubuntu",
-        })
+        self.harness.update_config(
+            {
+                "admin_email": "hello@ubuntu.com",
+                "admin_name": "Hello Ubuntu",
+            }
+        )
         self.log_mock.assert_any_call(
             "Admin email, name, and password required for bootstrap account"
         )
@@ -2292,34 +2310,40 @@ class TestBootstrapAccount(unittest.TestCase):
 
     @patch("charm.update_service_conf")
     def test_bootstrap_account_password_redacted(self, _):
-        self.harness.update_config({
-            "admin_email": "hello@ubuntu.com",
-            "admin_name": "Hello Ubuntu",
-            "admin_password": "secret123",
-            "registration_key": "secret123",
-            "root_url": "https://www.landscape.com",
-        })
+        self.harness.update_config(
+            {
+                "admin_email": "hello@ubuntu.com",
+                "admin_name": "Hello Ubuntu",
+                "admin_password": "secret123",
+                "registration_key": "secret123",
+                "root_url": "https://www.landscape.com",
+            }
+        )
         for mock_call in self.log_info_mock.call_args_list:
             self.assertNotIn("secret123", str(mock_call.args))
 
     @patch("charm.update_service_conf")
     def test_bootstrap_account_skips_when_no_root_url_and_no_leader_ip(self, _):
         """If neither root_url nor leader_ip is available, skip bootstrap."""
-        self.harness.update_config({
-            "admin_email": "hello@ubuntu.com",
-            "admin_name": "Hello Ubuntu",
-            "admin_password": "password",
-        })
+        self.harness.update_config(
+            {
+                "admin_email": "hello@ubuntu.com",
+                "admin_name": "Hello Ubuntu",
+                "admin_password": "password",
+            }
+        )
         self.assertEqual(len(self._bootstrap_calls()), 0)
 
     @patch("charm.update_service_conf")
     def test_bootstrap_account_uses_leader_ip_when_no_root_url(self, _):
         self.harness.charm._stored.leader_ip = "10.0.0.1"
-        self.harness.update_config({
-            "admin_email": "hello@ubuntu.com",
-            "admin_name": "Hello Ubuntu",
-            "admin_password": "password",
-        })
+        self.harness.update_config(
+            {
+                "admin_email": "hello@ubuntu.com",
+                "admin_name": "Hello Ubuntu",
+                "admin_password": "password",
+            }
+        )
         calls = self._bootstrap_calls()
         self.assertEqual(len(calls), 1)
         self.assertIn(
@@ -2332,12 +2356,14 @@ class TestBootstrapAccount(unittest.TestCase):
         """If config root_url and leader_ip are both set, use config url"""
         self.harness.charm._stored.leader_ip = "10.0.0.1"
         config_root_url = "https://www.landscape.com"
-        self.harness.update_config({
-            "admin_email": "hello@ubuntu.com",
-            "admin_name": "Hello Ubuntu",
-            "admin_password": "password",
-            "root_url": config_root_url,
-        })
+        self.harness.update_config(
+            {
+                "admin_email": "hello@ubuntu.com",
+                "admin_name": "Hello Ubuntu",
+                "admin_password": "password",
+                "root_url": config_root_url,
+            }
+        )
         calls = self._bootstrap_calls()
         self.assertEqual(len(calls), 1)
         self.assertIn(config_root_url, calls[0].args[0])

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -289,6 +289,97 @@ root-url = https://overridden.example.com
         assert config["api"]["root-url"] == "https://overridden.example.com"
         assert config["package-upload"]["root-url"] == "https://overridden.example.com"
 
+    def test_demo_data_enabled_is_forwarded_to_schema_migration(
+        self,
+        replicas_network_state,
+    ):
+        """
+        If `demo_data` is enabled and db config is present, pass it through to
+        schema migration.
+        """
+        ctx = Context(LandscapeServerCharm)
+        state = State(
+            **replicas_network_state,
+            config={
+                "db_schema_user": "landscape",
+                "demo_data": True,
+            },
+        )
+
+        with (
+            patch("charm.update_db_conf"),
+            patch.object(
+                LandscapeServerCharm,
+                "_migrate_schema_bootstrap",
+                return_value=True,
+            ) as migrate_schema_bootstrap,
+        ):
+            ctx.run(ctx.on.config_changed(), state)
+
+        migrate_schema_bootstrap.assert_called_once_with(demo_data=True)
+
+    def test_demo_data_not_forced_when_disabled(
+        self,
+        replicas_network_state,
+    ):
+        """
+        If `demo_data` is disabled, schema migration must keep demo data off.
+        """
+        ctx = Context(LandscapeServerCharm)
+        state = State(
+            **replicas_network_state,
+            config={
+                "db_schema_user": "landscape",
+                "demo_data": False,
+            },
+        )
+
+        with (
+            patch("charm.update_db_conf"),
+            patch.object(
+                LandscapeServerCharm,
+                "_migrate_schema_bootstrap",
+                return_value=True,
+            ) as migrate_schema_bootstrap,
+        ):
+            ctx.run(ctx.on.config_changed(), state)
+
+        migrate_schema_bootstrap.assert_called_once_with(demo_data=False)
+
+    def test_demo_data_standalone_updates_wsl_distributions(
+        self,
+        replicas_network_state,
+    ):
+        """
+        Standalone demo data bootstrap also refreshes stock WSL distributions.
+        """
+        ctx = Context(LandscapeServerCharm)
+        state = State(
+            **replicas_network_state,
+            config={
+                "db_schema_user": "landscape",
+                "demo_data": True,
+                "deployment_mode": "standalone",
+            },
+        )
+
+        with (
+            patch("charm.update_db_conf"),
+            patch.object(
+                LandscapeServerCharm,
+                "_migrate_schema_bootstrap",
+                return_value=True,
+            ),
+            patch.object(
+                LandscapeServerCharm,
+                "_update_wsl_distributions",
+                return_value=True,
+            ) as update_wsl_distributions,
+        ):
+            ctx.run(ctx.on.config_changed(), state)
+
+        update_wsl_distributions.assert_called_once_with()
+
     def test_hostagent_services_default(
         self,
         replicas_network_state,
@@ -1066,6 +1157,120 @@ class TestCharm(unittest.TestCase):
             [SCHEMA_SCRIPT, "--bootstrap", "--db-owner-role", "charmed_dba"],
             env={"PATH": "/usr/bin"},
         )
+        self.assertTrue(result)
+
+    @patch("charm.get_modified_env_vars", return_value={"PATH": "/usr/bin"})
+    def test_migrate_schema_bootstrap_demo_data_flags(self, get_env):
+        with patch("charm.check_call") as check_call_mock:
+            result = self.harness.charm._migrate_schema_bootstrap(demo_data=True)
+
+        check_call_mock.assert_called_once_with(
+            [
+                SCHEMA_SCRIPT,
+                "--bootstrap",
+                "--with-computers",
+                "--with-free-disk-space",
+                "--with-free-memory-and-swap",
+                "--with-load-averages",
+                "--with-temperatures",
+                "--with-network-traffic",
+                "--with-active-processes",
+                "--with-packages",
+                "--with-package-activities",
+                "--with-script-activities",
+                "--with-users-and-groups",
+                "--with-cpu-usage",
+                "--with-ceph-usage",
+                "--with-compute-usage",
+                "--with-swift-usage",
+                "--with-user-and-group-activities",
+                "--with-custom-graph",
+                "--with-scripts",
+                "--with-account-password",
+                "foo",
+            ],
+            env={"PATH": "/usr/bin"},
+        )
+        self.assertTrue(result)
+
+    @patch("charm.get_modified_env_vars", return_value={"PATH": "/usr/bin"})
+    def test_migrate_schema_bootstrap_standalone_includes_root_url_and_system_email(
+        self, get_env
+    ):
+        root_url = "https://landscape.local/"
+        system_email = "landscape-devel@lists.canonical.com"
+        self.harness.update_config(
+            {
+                "deployment_mode": "standalone",
+                "root_url": root_url,
+                "system_email": system_email,
+            }
+        )
+
+        with patch("charm.check_call") as check_call_mock:
+            result = self.harness.charm._migrate_schema_bootstrap(demo_data=True)
+
+        called_args = check_call_mock.call_args.args[0]
+        assert "--with-root-url" in called_args
+        assert "--with-system-email" in called_args
+        assert root_url in called_args
+        assert system_email in called_args
+        self.assertTrue(result)
+
+    @patch("charm.get_modified_env_vars", return_value={"PATH": "/usr/bin"})
+    def test_migrate_schema_bootstrap_demo_data_flags_saas(self, get_env):
+        self.harness.charm.charm_config.deployment_mode = "prod"
+
+        with patch("charm.check_call") as check_call_mock:
+            result = self.harness.charm._migrate_schema_bootstrap(demo_data=True)
+
+        called_args = check_call_mock.call_args.args[0]
+        assert "--with-hardware" in called_args
+        assert "--with-account-password" not in called_args
+        self.assertEqual(
+            check_call_mock.call_args.kwargs["env"],
+            {"PATH": "/usr/bin"},
+        )
+        self.assertTrue(result)
+
+    @patch("charm.get_modified_env_vars", return_value={"PATH": "/usr/bin"})
+    def test_migrate_schema_bootstrap_override_args(self, get_env):
+        self.harness.update_config(
+            {
+                "bootstrap_schema_override_args": (
+                    "--with-openstack,--with-extra-computers,10"
+                )
+            }
+        )
+
+        with patch("charm.check_call") as check_call_mock:
+            result = self.harness.charm._migrate_schema_bootstrap()
+
+        check_call_mock.assert_called_once_with(
+            [
+                SCHEMA_SCRIPT,
+                "--bootstrap",
+                "--with-openstack",
+                "--with-extra-computers",
+                "10",
+            ],
+            env={"PATH": "/usr/bin"},
+        )
+        self.assertTrue(result)
+
+    @patch("charm.get_modified_env_vars", return_value={"PATH": "/usr/bin"})
+    def test_migrate_schema_bootstrap_uses_registration_key_for_account_password(
+        self, get_env
+    ):
+        registration_key = "super-secret-registration-key"
+        self.harness.update_config({"registration_key": registration_key})
+
+        with patch("charm.check_call") as check_call_mock:
+            result = self.harness.charm._migrate_schema_bootstrap(demo_data=True)
+
+        called_args = check_call_mock.call_args.args[0]
+        password_idx = called_args.index("--with-account-password") + 1
+        assert called_args[password_idx] == registration_key
         self.assertTrue(result)
 
     @patch.dict(

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1175,6 +1175,7 @@ class TestCharm(unittest.TestCase):
                 "--with-temperatures",
                 "--with-network-traffic",
                 "--with-active-processes",
+                "--with-hardware",
                 "--with-packages",
                 "--with-package-activities",
                 "--with-script-activities",
@@ -1199,13 +1200,11 @@ class TestCharm(unittest.TestCase):
     ):
         root_url = "https://landscape.local/"
         system_email = "landscape-devel@lists.canonical.com"
-        self.harness.update_config(
-            {
-                "deployment_mode": "standalone",
-                "root_url": root_url,
-                "system_email": system_email,
-            }
-        )
+        self.harness.update_config({
+            "deployment_mode": "standalone",
+            "root_url": root_url,
+            "system_email": system_email,
+        })
 
         with patch("charm.check_call") as check_call_mock:
             result = self.harness.charm._migrate_schema_bootstrap(demo_data=True)
@@ -1226,7 +1225,7 @@ class TestCharm(unittest.TestCase):
 
         called_args = check_call_mock.call_args.args[0]
         assert "--with-hardware" in called_args
-        assert "--with-account-password" not in called_args
+        assert "--with-account-password" in called_args
         self.assertEqual(
             check_call_mock.call_args.kwargs["env"],
             {"PATH": "/usr/bin"},
@@ -1235,13 +1234,11 @@ class TestCharm(unittest.TestCase):
 
     @patch("charm.get_modified_env_vars", return_value={"PATH": "/usr/bin"})
     def test_migrate_schema_bootstrap_override_args(self, get_env):
-        self.harness.update_config(
-            {
-                "bootstrap_schema_override_args": (
-                    "--with-openstack,--with-extra-computers,10"
-                )
-            }
-        )
+        self.harness.update_config({
+            "bootstrap_schema_override_args": (
+                "--with-openstack,--with-extra-computers,10"
+            )
+        })
 
         with patch("charm.check_call") as check_call_mock:
             result = self.harness.charm._migrate_schema_bootstrap()
@@ -1373,9 +1370,9 @@ class TestCharm(unittest.TestCase):
     def test_update_ready_status_not_running(self):
         self.harness.charm.unit.status = WaitingStatus()
 
-        self.harness.charm._stored.ready.update(
-            {k: True for k in self.harness.charm._stored.ready.keys()}
-        )
+        self.harness.charm._stored.ready.update({
+            k: True for k in self.harness.charm._stored.ready.keys()
+        })
 
         patches = patch.multiple(
             "charm",
@@ -1397,9 +1394,9 @@ class TestCharm(unittest.TestCase):
     def test_update_ready_status_running(self):
         self.harness.charm.unit.status = WaitingStatus()
 
-        self.harness.charm._stored.ready.update(
-            {k: True for k in self.harness.charm._stored.ready.keys()}
-        )
+        self.harness.charm._stored.ready.update({
+            k: True for k in self.harness.charm._stored.ready.keys()
+        })
         self.harness.charm._stored.running = True
 
         self.harness.charm._update_ready_status()
@@ -1411,9 +1408,9 @@ class TestCharm(unittest.TestCase):
     def test_update_ready_status_called_process_error(self):
         self.harness.charm.unit.status = WaitingStatus()
 
-        self.harness.charm._stored.ready.update(
-            {k: True for k in self.harness.charm._stored.ready.keys()}
-        )
+        self.harness.charm._stored.ready.update({
+            k: True for k in self.harness.charm._stored.ready.keys()
+        })
 
         patches = patch.multiple(
             "charm",
@@ -1482,18 +1479,16 @@ class TestCharm(unittest.TestCase):
         self.assertIsInstance(status, BlockedStatus)
         self.assertFalse(self.harness.charm._stored.ready["db"])
 
-        update_service_conf_mock.assert_called_once_with(
-            {
-                "stores": {
-                    "host": "1.2.3.4:5678",
-                    "password": "testpass",
-                },
-                "schema": {
-                    "store_user": "testuser",
-                    "store_password": "testpass",
-                },
-            }
-        )
+        update_service_conf_mock.assert_called_once_with({
+            "stores": {
+                "host": "1.2.3.4:5678",
+                "password": "testpass",
+            },
+            "schema": {
+                "store_user": "testuser",
+                "store_password": "testpass",
+            },
+        })
 
     @patch("charm.update_service_conf")
     def test_on_manual_db_config_change(self, _):
@@ -1530,13 +1525,11 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(update_service_conf_mock.call_count, 2)
         self.assertEqual(
             update_service_conf_mock.call_args_list[1],
-            call(
-                {
-                    "stores": {
-                        "host": "hello:world",
-                    },
-                }
-            ),
+            call({
+                "stores": {
+                    "host": "hello:world",
+                },
+            }),
         )
 
     @patch("charm.update_service_conf")
@@ -1718,14 +1711,12 @@ class TestCharm(unittest.TestCase):
         self.assertTrue(self.harness.charm._stored.ready["inbound-amqp"])
         self.assertTrue(self.harness.charm._stored.ready["outbound-amqp"])
 
-        mock_update_conf.assert_called_once_with(
-            {
-                "broker": {
-                    "host": ",".join(hostname),
-                    "password": password,
-                },
-            }
-        )
+        mock_update_conf.assert_called_once_with({
+            "broker": {
+                "host": ",".join(hostname),
+                "password": password,
+            },
+        })
 
     def test_amqp_relation_changed_outbound_first(self):
         """
@@ -1762,14 +1753,12 @@ class TestCharm(unittest.TestCase):
         self.assertTrue(self.harness.charm._stored.ready["inbound-amqp"])
         self.assertTrue(self.harness.charm._stored.ready["outbound-amqp"])
 
-        mock_update_conf.assert_called_once_with(
-            {
-                "broker": {
-                    "host": hostname,
-                    "password": password,
-                },
-            }
-        )
+        mock_update_conf.assert_called_once_with({
+            "broker": {
+                "host": hostname,
+                "password": password,
+            },
+        })
 
     def test_configure_smtp_relay_host(self):
         mock_postfix_cf = os.path.join(self.tempdir.name, "my_postfix.cf")
@@ -2155,13 +2144,11 @@ class TestCharm(unittest.TestCase):
             )
 
         self.harness.charm._update_nrpe_checks.assert_called_once()
-        mock_update_conf.assert_called_once_with(
-            {
-                "package-search": {
-                    "host": "localhost",
-                },
-            }
-        )
+        mock_update_conf.assert_called_once_with({
+            "package-search": {
+                "host": "localhost",
+            },
+        })
 
     def test_on_replicas_relation_changed_non_leader(self):
         """
@@ -2181,13 +2168,11 @@ class TestCharm(unittest.TestCase):
             )
 
         self.harness.charm._update_nrpe_checks.assert_called_once()
-        mock_update_conf.assert_called_once_with(
-            {
-                "package-search": {
-                    "host": "test",
-                },
-            }
-        )
+        mock_update_conf.assert_called_once_with({
+            "package-search": {
+                "host": "test",
+            },
+        })
 
 
 class TestMultiplePPAs:
@@ -2296,12 +2281,10 @@ class TestBootstrapAccount(unittest.TestCase):
 
     @patch("charm.update_service_conf")
     def test_bootstrap_account_doesnt_run_with_missing_configs(self, _):
-        self.harness.update_config(
-            {
-                "admin_email": "hello@ubuntu.com",
-                "admin_name": "Hello Ubuntu",
-            }
-        )
+        self.harness.update_config({
+            "admin_email": "hello@ubuntu.com",
+            "admin_name": "Hello Ubuntu",
+        })
         self.log_mock.assert_any_call(
             "Admin email, name, and password required for bootstrap account"
         )
@@ -2309,40 +2292,34 @@ class TestBootstrapAccount(unittest.TestCase):
 
     @patch("charm.update_service_conf")
     def test_bootstrap_account_password_redacted(self, _):
-        self.harness.update_config(
-            {
-                "admin_email": "hello@ubuntu.com",
-                "admin_name": "Hello Ubuntu",
-                "admin_password": "secret123",
-                "registration_key": "secret123",
-                "root_url": "https://www.landscape.com",
-            }
-        )
+        self.harness.update_config({
+            "admin_email": "hello@ubuntu.com",
+            "admin_name": "Hello Ubuntu",
+            "admin_password": "secret123",
+            "registration_key": "secret123",
+            "root_url": "https://www.landscape.com",
+        })
         for mock_call in self.log_info_mock.call_args_list:
             self.assertNotIn("secret123", str(mock_call.args))
 
     @patch("charm.update_service_conf")
     def test_bootstrap_account_skips_when_no_root_url_and_no_leader_ip(self, _):
         """If neither root_url nor leader_ip is available, skip bootstrap."""
-        self.harness.update_config(
-            {
-                "admin_email": "hello@ubuntu.com",
-                "admin_name": "Hello Ubuntu",
-                "admin_password": "password",
-            }
-        )
+        self.harness.update_config({
+            "admin_email": "hello@ubuntu.com",
+            "admin_name": "Hello Ubuntu",
+            "admin_password": "password",
+        })
         self.assertEqual(len(self._bootstrap_calls()), 0)
 
     @patch("charm.update_service_conf")
     def test_bootstrap_account_uses_leader_ip_when_no_root_url(self, _):
         self.harness.charm._stored.leader_ip = "10.0.0.1"
-        self.harness.update_config(
-            {
-                "admin_email": "hello@ubuntu.com",
-                "admin_name": "Hello Ubuntu",
-                "admin_password": "password",
-            }
-        )
+        self.harness.update_config({
+            "admin_email": "hello@ubuntu.com",
+            "admin_name": "Hello Ubuntu",
+            "admin_password": "password",
+        })
         calls = self._bootstrap_calls()
         self.assertEqual(len(calls), 1)
         self.assertIn(
@@ -2355,14 +2332,12 @@ class TestBootstrapAccount(unittest.TestCase):
         """If config root_url and leader_ip are both set, use config url"""
         self.harness.charm._stored.leader_ip = "10.0.0.1"
         config_root_url = "https://www.landscape.com"
-        self.harness.update_config(
-            {
-                "admin_email": "hello@ubuntu.com",
-                "admin_name": "Hello Ubuntu",
-                "admin_password": "password",
-                "root_url": config_root_url,
-            }
-        )
+        self.harness.update_config({
+            "admin_email": "hello@ubuntu.com",
+            "admin_name": "Hello Ubuntu",
+            "admin_password": "password",
+            "root_url": config_root_url,
+        })
         calls = self._bootstrap_calls()
         self.assertEqual(len(calls), 1)
         self.assertIn(config_root_url, calls[0].args[0])

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -70,6 +70,7 @@ def test_defaults():
     assert config.hostagent_server_base_port == 50052
     assert config.ubuntu_installer_attach_base_port == 53354
     assert config.gpg_secret_id is None
+    assert config.bootstrap_schema_override_args is None
 
 
 @pytest.mark.parametrize(
@@ -265,3 +266,19 @@ def test_landscape_ppas_strips_whitespace():
         }
     )
     assert config.landscape_ppas == ["ppa:foo/bar", "ppa:baz/qux"]
+
+
+def test_bootstrap_schema_override_args_list():
+    config = LandscapeCharmConfiguration(
+        **{
+            **get_config_defaults(),
+            "bootstrap_schema_override_args": (
+                "--with-openstack, --with-extra-computers, 10 "
+            ),
+        }
+    )
+    assert config.bootstrap_schema_override_args_list == [
+        "--with-openstack",
+        "--with-extra-computers",
+        "10",
+    ]

--- a/tests/unit/test_database_relation.py
+++ b/tests/unit/test_database_relation.py
@@ -250,7 +250,7 @@ class TestDatabaseRelation:
             password="secret",
             schema_password=None,
         )
-        migrate_mock.assert_called_once_with("postgres")
+        migrate_mock.assert_called_once_with("postgres", demo_data=False)
         grant_role_mock.assert_not_called()
         update_ready.assert_called_once_with(restart_services=True)
         assert isinstance(status, ActiveStatus)
@@ -321,9 +321,72 @@ class TestDatabaseRelation:
             password="landscape-pass",
             schema_password=None,
         )
-        migrate_mock.assert_called_once_with("postgres")
+        migrate_mock.assert_called_once_with("postgres", demo_data=False)
         grant_role_mock.assert_not_called()
         update_ready.assert_called_once_with(restart_services=True)
+
+    def test_database_relation_passes_demo_data_to_schema_bootstrap(self):
+        ctx = Context(LandscapeServerCharm)
+        relation = Relation("database", remote_app_name="postgresql")
+
+        fetch_context = DatabaseConnectionContext(
+            host="1.2.3.4",
+            port="5432",
+            username="relation-9",
+            password="secret",
+            version="16.9",
+        )
+
+        with (
+            patch("charm.update_db_conf") as update_db_conf,
+            patch(
+                "charm.LandscapeServerCharm._migrate_schema_bootstrap",
+                return_value=True,
+            ) as migrate_mock,
+            patch(
+                "charm.LandscapeServerCharm._update_wsl_distributions",
+                return_value=True,
+            ),
+            patch(
+                "charm.get_postgres_roles",
+                return_value=PostgresRoles(
+                    relation="relation-9",
+                    application="landscape-app",
+                    owner="charmed_dba",
+                    superuser=None,
+                ),
+            ),
+            patch("charm.grant_role") as grant_role_mock,
+            patch("charm.fetch_postgres_relation_data", return_value=fetch_context),
+        ):
+            state_in = self._state(
+                relation=relation,
+                leader=True,
+                config={"demo_data": True},
+            )
+
+            with ctx(ctx.on.start(), state_in) as manager:
+                manager.charm.database = Mock()
+                manager.charm._database_relation_changed(
+                    mock.create_autospec(DatabaseCreatedEvent)
+                )
+
+        migrate_mock.assert_called_once_with("charmed_dba", demo_data=True)
+        grant_role_mock.assert_called_once_with(
+            host="1.2.3.4",
+            port="5432",
+            relation_user="relation-9",
+            relation_password="secret",
+            role="charmed_dml",
+            user="landscape-app",
+        )
+        update_db_conf.assert_called_once_with(
+            host="1.2.3.4",
+            port="5432",
+            user="relation-9",
+            password="secret",
+            schema_password=None,
+        )
 
     def test_database_relation_pg16_grants_roles(self):
         ctx = Context(LandscapeServerCharm)
@@ -367,7 +430,7 @@ class TestDatabaseRelation:
                     mock.create_autospec(DatabaseCreatedEvent)
                 )
 
-        migrate_mock.assert_called_once_with("charmed_dba")
+        migrate_mock.assert_called_once_with("charmed_dba", demo_data=False)
         grant_role_mock.assert_has_calls(
             [
                 call(


### PR DESCRIPTION
## Description of changes

This PR adds demo-data bootstrap support and keeps it consistent across all database setup paths in the charm.

- Added `demo_data` schema-bootstrap argument handling for:
  - config-changed manual DB override flow
  - legacy `db` relation flow
  - modern `database` relation flow
- Aligned demo-data argument sets with upstream `landscape-server` behavior from `mk/database.mk`:
  - self-hosted mode uses self-hosted sample-data flags
  - SaaS mode uses SaaS sample-data flags
- Synced demo account password with charm `registration_key` when present.
- Added optional `bootstrap_schema_override_args` config (comma-separated) to append custom `landscape-schema --bootstrap` args.
- For self-hosted demo-data bootstrap, run WSL distribution refresh after schema bootstrap.
- Updated integration DB query helper to safely shell-quote query inputs and parse `stores.host` with `rsplit(":", 1)` for robust host/port parsing.
- Added integration coverage for:
  - demo data presence when `demo_data=true`
  - registration key parity with `account.registration_key`
- Added `bundle-examples/saas.bundle.yaml` for testing demo data in SaaS mode.

## Manual testing

### Self-hosted mode

The default `bundle-examples/bundle.yaml` ships with `demo_data: true` and `root_url: https://landscape.local/`. Deploy:

```bash
make deploy
```

Get the HAProxy unit IP from `juju status -m landscape-server-operator-build`, add it to `/etc/hosts`:

```bash
echo 'HAPROXY_IP landscape.local' | sudo tee -a /etc/hosts
```

Open `https://landscape.local` in a browser and log in as `john@example.com`.

Expected result: login succeeds and demo computers/data are visible in the UI.

### SaaS mode

Tear down the existing model, then deploy using the SaaS bundle:

```bash
make BUNDLE_PATH=./bundle-examples/saas.bundle.yaml deploy
```

Get the HAProxy unit IP from `juju status -m landscape-server-operator-build`, add it to `/etc/hosts`, then open `https://landscape.local` in a browser.

Login should succeed, `self_hosted` is `false` (verify via `curl -k https://landscape.local/api/about`), and demo data is seeded.

To confirm at the DB level, get credentials from the charm:

```bash
juju run -m landscape-server-operator-build landscape-server/leader get-service-conf --format json | python3 -c "import json,sys; d=next(iter(json.load(sys.stdin).values())); s=json.loads(d['results']['config'])['stores']; print('host=',s['host']); print('user=',s['user']); print('password=',s['password']); print('main=',s['main'])"
```

```bash
PGPASSWORD='DB_PASSWORD' psql -h DB_HOST -p DB_PORT -U DB_USER -d DB_MAIN -tAc "SELECT COUNT(*) FROM computer;"
```

Expected result: 23

## Related PRs/links

- Upstream reference: https://github.com/canonical/landscape-server/blob/5f3a8237159a98871864fe9abdeb6765b3c2b9a3/mk/database.mk