### PR TITLE
fix: permissions for the charm build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
         name: Build charm
         uses: ./.github/workflows/build.yaml
         permissions:
-            actions: read # Needed to manage the artifact cache (used by build_charm.yaml)
+            actions: read # Needed to manage the artifact cache (used by build_charm.yaml from data-platform-workflows)
             contents: read
 
     release:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,6 +25,9 @@ jobs:
     build:
         name: Build charm
         uses: ./.github/workflows/build.yaml
+        permissions:
+            actions: read # Needed to manage the artifact cache (used by build_charm.yaml)
+            contents: read
 
     release:
         name: Release charm


### PR DESCRIPTION
Should hopefully fix [these errors](https://github.com/canonical/landscape-server-operator/actions/runs/26312141402/workflow).