### PR TITLE
feat: integrate with landscape debarchive charm

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -53,6 +53,8 @@ requires:
     limit: 1
 
 provides:
+  debarchive:
+    interface: landscape-debarchive
   data:
     interface: block-storage
     scope: container

--- a/src/charm.py
+++ b/src/charm.py
@@ -592,7 +592,10 @@ class LandscapeServerCharm(CharmBase):
                     {"cookie-encryption-key": cookie_encryption_key}
                 )
 
-        if (secret_token) and (secret_token != self._stored.secret_token):
+        secret_token_changed = (
+            secret_token and secret_token != self._stored.secret_token
+        )
+        if secret_token_changed:
             self._write_secret_token(secret_token)
             self._stored.secret_token = secret_token
 
@@ -606,7 +609,9 @@ class LandscapeServerCharm(CharmBase):
 
         self._update_ready_status(restart_services=True)
         self._provide_all_haproxy_route_requirements()
-        self._update_debarchive_relations()
+        self._update_debarchive_relations(
+            notify_secret_token_changed=bool(secret_token_changed)
+        )
 
     def _set_ports(self):
         worker_counts = self.charm_config.worker_counts
@@ -1500,7 +1505,9 @@ command[check_{service}]=/usr/local/lib/nagios/plugins/check_systemd.py {service
             }
         )
 
-    def _update_debarchive_relations(self) -> None:
+    def _update_debarchive_relations(
+        self, notify_secret_token_changed: bool = False
+    ) -> None:
         """Publish the Landscape root URL to all related debarchive charms."""
         if not self.unit.is_leader():
             return
@@ -1531,8 +1538,8 @@ command[check_{service}]=/usr/local/lib/nagios/plugins/check_systemd.py {service
         hostname = leader_ip
         if self.charm_config.root_url:
             parsed = urlparse(self.charm_config.root_url)
-            if name := parsed.hostname:
-                hostname = name
+            if parsed.hostname:
+                hostname = parsed.hostname
 
         for relation in relations:
             # Reuse the per-relation secret rather than creating (and leaking) a
@@ -1541,7 +1548,8 @@ command[check_{service}]=/usr/local/lib/nagios/plugins/check_systemd.py {service
             if existing_id:
                 try:
                     secret = self.model.get_secret(id=existing_id)
-                    secret.set_content({"secret-token": secret_token})
+                    if notify_secret_token_changed:
+                        secret.set_content({"secret-token": secret_token})
                 except (SecretNotFoundError, ModelError):
                     logger.warning(
                         "Debarchive relation has stale secret-token-id %s; "
@@ -1554,6 +1562,11 @@ command[check_{service}]=/usr/local/lib/nagios/plugins/check_systemd.py {service
             secret.grant(relation)
             relation.data[self.app]["hostname"] = hostname
             relation.data[self.app]["secret-token-id"] = secret.id
+            if notify_secret_token_changed:
+                revision = int(
+                    relation.data[self.app].get("secret-token-revision", "0")
+                )
+                relation.data[self.app]["secret-token-revision"] = str(revision + 1)
 
     def _debarchive_relation_joined(self, event: RelationJoinedEvent) -> None:
         """Provide the Landscape root URL when a debarchive charm relates."""

--- a/src/charm.py
+++ b/src/charm.py
@@ -260,6 +260,10 @@ class LandscapeServerCharm(CharmBase):
             self.on.application_dashboard_relation_joined,
             self._application_dashboard_relation_joined,
         )
+        self.framework.observe(
+            self.on.debarchive_relation_joined,
+            self._debarchive_relation_joined,
+        )
 
         # Leadership/peering
         self.framework.observe(self.on.leader_elected, self._leader_elected)
@@ -568,6 +572,7 @@ class LandscapeServerCharm(CharmBase):
 
         self._update_ready_status(restart_services=True)
         self._provide_all_haproxy_route_requirements()
+        self._update_debarchive_relations()
 
     def _set_ports(self):
         worker_counts = self.charm_config.worker_counts
@@ -1260,6 +1265,7 @@ class LandscapeServerCharm(CharmBase):
                 "/api",
                 "/upload",
                 "/repository",
+                "/debarchive",
             ],
         )
         self.pingserver_haproxy_route.provide_haproxy_route_requirements(
@@ -1438,6 +1444,40 @@ command[check_{service}]=/usr/local/lib/nagios/plugins/check_systemd.py {service
             }
         )
 
+    def _update_debarchive_relations(self) -> None:
+        """Publish the Landscape root URL to all related debarchive charms."""
+        if not self.unit.is_leader():
+            return
+
+        relations = self.model.relations.get("debarchive", [])
+        if not relations:
+            return
+
+        leader_ip = self._stored.leader_ip
+        if not leader_ip:
+            logger.warning(
+                "Skipping debarchive relation update: leader IP is not yet available"
+            )
+            return
+
+        hostname = leader_ip
+        if self.charm_config.root_url:
+            parsed = urlparse(self.charm_config.root_url)
+            if name := parsed.hostname:
+                hostname = name
+
+        secret_token = self._get_secret_token()
+        secret = self.app.add_secret({"secret-token": secret_token})
+
+        for relation in relations:
+            secret.grant(relation)
+            relation.data[self.app]["hostname"] = hostname
+            relation.data[self.app]["secret-id"] = secret.id
+
+    def _debarchive_relation_joined(self, event: RelationJoinedEvent) -> None:
+        """Provide the Landscape root URL when a debarchive charm relates."""
+        self._update_debarchive_relations()
+
     def _leader_elected(self, event: LeaderElectedEvent) -> None:
         # Just because we received this event does not mean we are
         # guaranteed to be the leader by the time we process it. See
@@ -1456,6 +1496,10 @@ command[check_{service}]=/usr/local/lib/nagios/plugins/check_systemd.py {service
                     },
                 }
             )
+
+            # Now that we (may) have a leader IP, refresh any debarchive
+            # relations that depend on it for their root URL fallback.
+            self._update_debarchive_relations()
 
         self._leader_changed()
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -284,11 +284,11 @@ class LandscapeServerCharm(CharmBase):
         )
         self.framework.observe(
             self.on.debarchive_relation_joined,
-            self._debarchive_relation_joined,
+            self._update_debarchive_relations,
         )
         self.framework.observe(
             self.on.debarchive_relation_changed,
-            self._debarchive_relation_changed,
+            self._update_debarchive_relations,
         )
 
         # Leadership/peering
@@ -1567,14 +1567,6 @@ command[check_{service}]=/usr/local/lib/nagios/plugins/check_systemd.py {service
                     relation.data[self.app].get("secret-token-revision", "0")
                 )
                 relation.data[self.app]["secret-token-revision"] = str(revision + 1)
-
-    def _debarchive_relation_joined(self, event: RelationJoinedEvent) -> None:
-        """Provide the Landscape root URL when a debarchive charm relates."""
-        self._update_debarchive_relations()
-
-    def _debarchive_relation_changed(self, event: RelationChangedEvent) -> None:
-        """Refresh debarchive relation data when the relation is updated."""
-        self._update_debarchive_relations()
 
     def _leader_elected(self, event: LeaderElectedEvent) -> None:
         # Just because we received this event does not mean we are

--- a/src/charm.py
+++ b/src/charm.py
@@ -1544,7 +1544,8 @@ command[check_{service}]=/usr/local/lib/nagios/plugins/check_systemd.py {service
                     secret.set_content({"secret-token": secret_token})
                 except (SecretNotFoundError, ModelError):
                     logger.warning(
-                        "Debarchive relation has stale secret-token-id %s; creating a new secret",
+                        "Debarchive relation has stale secret-token-id %s; "
+                        "creating a new secret",
                         existing_id,
                     )
                     secret = self.app.add_secret({"secret-token": secret_token})

--- a/src/charm.py
+++ b/src/charm.py
@@ -286,6 +286,10 @@ class LandscapeServerCharm(CharmBase):
             self.on.debarchive_relation_joined,
             self._debarchive_relation_joined,
         )
+        self.framework.observe(
+            self.on.debarchive_relation_changed,
+            self._debarchive_relation_changed,
+        )
 
         # Leadership/peering
         self.framework.observe(self.on.leader_elected, self._leader_elected)
@@ -1507,8 +1511,20 @@ command[check_{service}]=/usr/local/lib/nagios/plugins/check_systemd.py {service
 
         leader_ip = self._stored.leader_ip
         if not leader_ip:
+            # `_stored.leader_ip` is only populated from replicas-relation-changed,
+            # which may not have fired yet (e.g. a single-unit deployment). Fall
+            # back to resolving our own bind address so we can still publish.
+            peer_relation = self.model.get_relation("replicas")
+            if peer_relation is not None:
+                binding = self.model.get_binding(peer_relation)
+                if binding and binding.network.bind_address:
+                    leader_ip = str(binding.network.bind_address)
+                    self._stored.leader_ip = leader_ip
+
+        secret_token = self._get_secret_token()
+        if not secret_token:
             logger.warning(
-                "Skipping debarchive relation update: leader IP is not yet available"
+                "Skipping debarchive relation update: secret token is not yet available"
             )
             return
 
@@ -1518,16 +1534,32 @@ command[check_{service}]=/usr/local/lib/nagios/plugins/check_systemd.py {service
             if name := parsed.hostname:
                 hostname = name
 
-        secret_token = self._get_secret_token()
-        secret = self.app.add_secret({"secret-token": secret_token})
-
         for relation in relations:
+            # Reuse the per-relation secret rather than creating (and leaking) a
+            # new one on every hook invocation.
+            existing_id = relation.data[self.app].get("secret-token-id")
+            if existing_id:
+                try:
+                    secret = self.model.get_secret(id=existing_id)
+                    secret.set_content({"secret-token": secret_token})
+                except (SecretNotFoundError, ModelError):
+                    logger.warning(
+                        "Debarchive relation has stale secret-token-id %s; creating a new secret",
+                        existing_id,
+                    )
+                    secret = self.app.add_secret({"secret-token": secret_token})
+            else:
+                secret = self.app.add_secret({"secret-token": secret_token})
             secret.grant(relation)
             relation.data[self.app]["hostname"] = hostname
-            relation.data[self.app]["secret-id"] = secret.id
+            relation.data[self.app]["secret-token-id"] = secret.id
 
     def _debarchive_relation_joined(self, event: RelationJoinedEvent) -> None:
         """Provide the Landscape root URL when a debarchive charm relates."""
+        self._update_debarchive_relations()
+
+    def _debarchive_relation_changed(self, event: RelationChangedEvent) -> None:
+        """Refresh debarchive relation data when the relation is updated."""
         self._update_debarchive_relations()
 
     def _leader_elected(self, event: LeaderElectedEvent) -> None:

--- a/tests/integration/bundle.yaml
+++ b/tests/integration/bundle.yaml
@@ -29,6 +29,10 @@ applications:
       enable_ubuntu_installer_attach: true
       root_url: https://landscape.local/
       redirect_https: none
+  landscape-debarchive:
+    charm: ../../landscape-debarchive-operator/landscape-debarchive_ubuntu@24.04-amd64.charm
+    num_units: 1
+    base: ubuntu@24.04
   haproxy:
     charm: ch:haproxy
     channel: 2.8/edge
@@ -41,6 +45,8 @@ relations:
   - [landscape-server:inbound-amqp, rabbitmq-server]
   - [landscape-server:outbound-amqp, rabbitmq-server]
   - [landscape-server:database, postgresql:database]
+  - [landscape-debarchive:database, postgresql:database]
+  - [landscape-server:debarchive, landscape-debarchive:landscape-server]
   - [haproxy:certificates, self-signed-certificates:certificates]
   - [haproxy:receive-ca-certs, self-signed-certificates:send-ca-cert]
   - [landscape-server:appserver-haproxy-route, haproxy:haproxy-route]

--- a/tests/integration/bundle.yaml
+++ b/tests/integration/bundle.yaml
@@ -30,7 +30,7 @@ applications:
       root_url: https://landscape.local/
       redirect_https: none
   landscape-debarchive:
-    charm: ../../landscape-debarchive-operator/landscape-debarchive_ubuntu@24.04-amd64.charm
+    charm: ../../landscape-debarchive_ubuntu@24.04-amd64.charm
     num_units: 1
     base: ubuntu@24.04
   haproxy:

--- a/tests/integration/test_bundle.py
+++ b/tests/integration/test_bundle.py
@@ -66,6 +66,63 @@ def _haproxy_ip(juju: jubilant.Juju, lbaas: jubilant.Juju) -> str:
     pytest.skip("No haproxy app found in local or lbaas model")
 
 
+def _leader_unit_name(juju: jubilant.Juju, app: str) -> str:
+    """Return the leader unit name for an application."""
+    app_status = juju.status().apps[app]
+    for name, unit_status in app_status.units.items():
+        if unit_status.leader:
+            return name
+    pytest.fail(f"No leader unit found for {app}")
+
+
+def _relation_app_data(juju: jubilant.Juju, unit: str, endpoint: str) -> dict:
+    """Return the local app databag for a unit's relation endpoint."""
+    ids_stdout = juju.cli("exec", "--unit", unit, "--", f"relation-ids {endpoint}")
+    ids = ids_stdout.strip().splitlines()
+    if not ids:
+        pytest.fail(f"No relation IDs found for endpoint {endpoint}")
+
+    data_stdout = juju.cli(
+        "exec",
+        "--unit",
+        unit,
+        "--",
+        f"relation-get --format=json -r {ids[0]} --app - {unit}",
+    )
+    data = json.loads(data_stdout)
+    return {k: v.strip('"') if isinstance(v, str) else v for k, v in data.items()}
+
+
+def test_debarchive_relation(juju: jubilant.Juju):
+    """Landscape Server and debarchive publish and consume relation data."""
+    juju.wait(jubilant.all_active, timeout=300)
+    status = juju.status()
+
+    if "landscape-debarchive" not in status.apps:
+        pytest.skip("landscape-debarchive not deployed")
+
+    landscape_relations = status.apps["landscape-server"].relations
+    debarchive_relations = status.apps["landscape-debarchive"].relations
+    assert "debarchive" in landscape_relations
+    assert "landscape-server" in debarchive_relations
+    assert "database" in debarchive_relations
+
+    leader_unit = _leader_unit_name(juju, "landscape-server")
+    data = _relation_app_data(juju, leader_unit, "debarchive")
+    expected_hostname = urlparse(
+        juju.config("landscape-server").get("root_url", "https://landscape.local/")
+    ).hostname
+
+    assert data["hostname"] == expected_hostname
+    assert data["secret-token-id"].startswith("secret://")
+
+    token = juju.ssh(
+        "landscape-debarchive/leader",
+        "sudo snap get landscape-debarchive deb.archive.jwt.secret",
+    ).strip()
+    assert token and token != "-"
+
+
 @pytest.mark.skipif(
     USE_HOST_JUJU_MODEL,
     reason=LIVE_MODEL_SKIP_REASON,

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -174,10 +174,49 @@ class TestDebarchiveRelation:
         app_data = self._debarchive_app_data(result)
         assert app_data["hostname"] == "10.0.0.1"
 
-        # The published secret-id resolves to a secret holding the token,
+        # The published secret-token-id resolves to a secret holding the token,
         # granted to the debarchive relation.
-        secret_id = app_data["secret-id"]
+        secret_id = app_data["secret-token-id"]
         secret = result.get_secret(id=secret_id)
+        assert secret.latest_content == {"secret-token": "s3cr3t"}
+
+    def test_relation_changed_refreshes_hostname_and_secret(self):
+        """The provider refreshes data when Juju fires relation-changed."""
+        context = Context(LandscapeServerCharm)
+        relation = Relation("debarchive")
+        state = State(
+            leader=True,
+            relations=[relation],
+            config={"secret_token": "s3cr3t"},
+            stored_states=[self._stored_leader_ip("10.0.0.1")],
+        )
+
+        result = context.run(context.on.relation_changed(relation), state)
+
+        app_data = self._debarchive_app_data(result)
+        assert app_data["hostname"] == "10.0.0.1"
+        secret = result.get_secret(id=app_data["secret-token-id"])
+        assert secret.latest_content == {"secret-token": "s3cr3t"}
+
+    def test_recreates_stale_secret_token_id(self):
+        """A stale published secret-token-id does not fail the relation hook."""
+        context = Context(LandscapeServerCharm)
+        relation = Relation(
+            "debarchive",
+            local_app_data={"secret-token-id": "secret:doesnotexist"},
+        )
+        state = State(
+            leader=True,
+            relations=[relation],
+            config={"secret_token": "s3cr3t"},
+            stored_states=[self._stored_leader_ip("10.0.0.1")],
+        )
+
+        result = context.run(context.on.relation_joined(relation), state)
+
+        app_data = self._debarchive_app_data(result)
+        assert app_data["secret-token-id"] != "secret:doesnotexist"
+        secret = result.get_secret(id=app_data["secret-token-id"])
         assert secret.latest_content == {"secret-token": "s3cr3t"}
 
     def test_configured_root_url_hostname_takes_precedence(self):
@@ -199,10 +238,10 @@ class TestDebarchiveRelation:
 
         assert self._debarchive_app_data(result)["hostname"] == "landscape.example.com"
 
-    def test_skips_when_leader_ip_unavailable(self):
+    def test_configured_root_url_publishes_without_leader_ip(self):
         """
-        Nothing is published until the leader IP is known, even when a
-        `root_url` is configured.
+        With `root_url` configured, the leader can publish relation data even
+        before the leader IP is known.
         """
         context = Context(LandscapeServerCharm)
         relation = Relation("debarchive")
@@ -217,8 +256,10 @@ class TestDebarchiveRelation:
 
         result = context.run(context.on.relation_joined(relation), state)
 
-        assert self._debarchive_app_data(result) == {}
-        assert result.secrets == frozenset()
+        app_data = self._debarchive_app_data(result)
+        assert app_data["hostname"] == "landscape.example.com"
+        secret = result.get_secret(id=app_data["secret-token-id"])
+        assert secret.latest_content == {"secret-token": "s3cr3t"}
 
     def test_non_leader_does_not_publish(self):
         """Non-leader units never write to the relation app databag."""

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -198,6 +198,40 @@ class TestDebarchiveRelation:
         secret = result.get_secret(id=app_data["secret-token-id"])
         assert secret.latest_content == {"secret-token": "s3cr3t"}
 
+    def test_config_changed_republishes_updated_secret_token(self):
+        """Config changes bump relation data when the shared secret changes."""
+        context = Context(LandscapeServerCharm)
+        secret = Secret(
+            tracked_content={"secret-token": "old-s3cr3t"},
+            owner="app",
+        )
+        relation = Relation(
+            "debarchive",
+            local_app_data={
+                "hostname": "10.0.0.1",
+                "secret-token-id": secret.id,
+                "secret-token-revision": "1",
+            },
+        )
+        state = State(
+            leader=True,
+            relations=[relation],
+            secrets=[secret],
+            config={
+                "secret_token": "new-s3cr3t",
+                "cookie_encryption_key": "cookie-key",
+            },
+            stored_states=[self._stored_leader_ip("10.0.0.1")],
+        )
+
+        result = context.run(context.on.config_changed(), state)
+
+        app_data = self._debarchive_app_data(result)
+        assert app_data["secret-token-id"] == secret.id
+        assert app_data["secret-token-revision"] == "2"
+        updated_secret = result.get_secret(id=secret.id)
+        assert updated_secret.latest_content == {"secret-token": "new-s3cr3t"}
+
     def test_recreates_stale_secret_token_id(self):
         """A stale published secret-token-id does not fail the relation hook."""
         context = Context(LandscapeServerCharm)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -134,6 +134,111 @@ class TestGrafanaMachineAgentRelation(unittest.TestCase):
             self.assertEqual(scrape_interval, scrape_job["scrape_interval"])
 
 
+class TestDebarchiveRelation:
+    """
+    Tests for the `debarchive` provider relation.
+
+    When a debarchive charm relates, the leader publishes the Landscape
+    hostname to the relation app databag along with a secret holding the
+    Landscape secret token, which it grants to the relation.
+    """
+
+    def _debarchive_app_data(self, state: State) -> dict:
+        for relation in state.relations:
+            if relation.endpoint == "debarchive":
+                return dict(relation.local_app_data)
+        raise ValueError("No debarchive relation found.")
+
+    def _stored_leader_ip(self, leader_ip: str) -> StoredState:
+        return StoredState(
+            owner_path="LandscapeServerCharm",
+            content={"leader_ip": leader_ip},
+        )
+
+    def test_publishes_leader_ip_hostname_and_secret(self):
+        """
+        With no `root_url` configured, the leader publishes the stored leader IP
+        as the hostname and shares the secret token via a granted secret.
+        """
+        context = Context(LandscapeServerCharm)
+        relation = Relation("debarchive")
+        state = State(
+            leader=True,
+            relations=[relation],
+            config={"secret_token": "s3cr3t"},
+            stored_states=[self._stored_leader_ip("10.0.0.1")],
+        )
+
+        result = context.run(context.on.relation_joined(relation), state)
+
+        app_data = self._debarchive_app_data(result)
+        assert app_data["hostname"] == "10.0.0.1"
+
+        # The published secret-id resolves to a secret holding the token,
+        # granted to the debarchive relation.
+        secret_id = app_data["secret-id"]
+        secret = result.get_secret(id=secret_id)
+        assert secret.latest_content == {"secret-token": "s3cr3t"}
+
+    def test_configured_root_url_hostname_takes_precedence(self):
+        """The hostname from a configured `root_url` is published instead of the
+        leader IP."""
+        context = Context(LandscapeServerCharm)
+        relation = Relation("debarchive")
+        state = State(
+            leader=True,
+            relations=[relation],
+            config={
+                "root_url": "https://landscape.example.com",
+                "secret_token": "s3cr3t",
+            },
+            stored_states=[self._stored_leader_ip("10.0.0.1")],
+        )
+
+        result = context.run(context.on.relation_joined(relation), state)
+
+        assert self._debarchive_app_data(result)["hostname"] == "landscape.example.com"
+
+    def test_skips_when_leader_ip_unavailable(self):
+        """
+        Nothing is published until the leader IP is known, even when a
+        `root_url` is configured.
+        """
+        context = Context(LandscapeServerCharm)
+        relation = Relation("debarchive")
+        state = State(
+            leader=True,
+            relations=[relation],
+            config={
+                "root_url": "https://landscape.example.com",
+                "secret_token": "s3cr3t",
+            },
+        )
+
+        result = context.run(context.on.relation_joined(relation), state)
+
+        assert self._debarchive_app_data(result) == {}
+        assert result.secrets == frozenset()
+
+    def test_non_leader_does_not_publish(self):
+        """Non-leader units never write to the relation app databag."""
+        context = Context(LandscapeServerCharm)
+        relation = Relation("debarchive")
+        state = State(
+            leader=False,
+            relations=[relation],
+            config={
+                "root_url": "https://landscape.example.com",
+                "secret_token": "s3cr3t",
+            },
+            stored_states=[self._stored_leader_ip("10.0.0.1")],
+        )
+
+        result = context.run(context.on.relation_joined(relation), state)
+
+        assert self._debarchive_app_data(result) == {}
+
+
 class TestOnConfigChanged:
     """
     Tests for `on.config_changed` hooks.


### PR DESCRIPTION
## Manual Testing
- Pack and deploy on new model `./bundle-examples/bundle.yaml`
- Pack and deploy on same model the debarchive charm from this pr https://github.com/canonical/landscape-debarchive-operator/pull/11
- Integrate the two charms together
- SSH or exec in the debarchive unit `sudo snap get landscape-debarchive -d` and verify the jwt secret is set the same as what is in the landscape server conf
- Verify in the logs that the hostname is passed into debarchive with `juju debug-log --include landscape-debarchive/0`
- To run integration test, copy the debarchive charm build to the root directory of the server charm