### PR TITLE
feat(terraform): expose machines option for charms in landscape-scalable module

### DIFF
--- a/terraform/product/modules/landscape-scalable/main.tf
+++ b/terraform/product/modules/landscape-scalable/main.tf
@@ -23,6 +23,7 @@ module "haproxy" {
   revision    = var.haproxy.revision
   base        = var.haproxy.base
   units       = var.haproxy.units
+  # machines is not supported by the external haproxy module (haproxy-rev331)
 
   count = var.haproxy != null && var.haproxy_route_offer_url == null ? 1 : 0
 }
@@ -37,6 +38,7 @@ module "postgresql" {
   revision    = var.postgresql.revision
   base        = var.postgresql.base
   units       = var.postgresql.units
+  # machines is not supported by the external postgresql module (v16/1.165.0)
 
   count = var.postgresql != null ? 1 : 0
 }
@@ -45,7 +47,8 @@ module "postgresql" {
 resource "juju_application" "rabbitmq_server" {
   name        = var.rabbitmq_server.app_name
   model_uuid  = var.model_uuid
-  units       = var.rabbitmq_server.units
+  units       = var.rabbitmq_server.machines == null ? var.rabbitmq_server.units : null
+  machines    = var.rabbitmq_server.machines
   constraints = var.rabbitmq_server.constraints
   config      = var.rabbitmq_server.config
 
@@ -469,7 +472,8 @@ resource "juju_integration" "landscape_server_postgresql_modern" {
 resource "juju_application" "tls_certificates" {
   name        = var.tls_certificates.app_name
   model_uuid  = var.model_uuid
-  units       = 1
+  units       = var.tls_certificates.machines == null ? 1 : null
+  machines    = var.tls_certificates.machines
   constraints = var.tls_certificates.constraints
 
   charm {

--- a/terraform/product/modules/landscape-scalable/variables.tf
+++ b/terraform/product/modules/landscape-scalable/variables.tf
@@ -47,6 +47,7 @@ variable "postgresql" {
     revision    = optional(number)
     base        = optional(string, "ubuntu@24.04")
     units       = optional(number, 1)
+    machines    = optional(set(string))
   })
 
   default  = {}
@@ -65,6 +66,7 @@ variable "haproxy" {
     revision    = optional(number)
     base        = optional(string, "ubuntu@24.04")
     units       = optional(number, 1)
+    machines    = optional(set(string))
   })
 
   default  = {}
@@ -91,6 +93,7 @@ variable "rabbitmq_server" {
     revision    = optional(number)
     base        = optional(string, "ubuntu@24.04")
     units       = optional(number, 1)
+    machines    = optional(set(string))
   })
 
   default  = {}
@@ -120,6 +123,7 @@ variable "tls_certificates" {
     constraints = optional(string, "arch=amd64")
     revision    = optional(number)
     base        = optional(string, "ubuntu@24.04")
+    machines    = optional(set(string))
   })
 
   default  = {}


### PR DESCRIPTION
## Summary

- Add `machines = optional(set(string))` to `haproxy`, `rabbitmq_server`, `postgresql`, and `tls_certificates` variable objects in the `landscape-scalable` module
- Wire up `machines` in `juju_application.rabbitmq_server` and `juju_application.tls_certificates`, using `machines == null ? units : null` pattern matching the landscape-server charm sub-module
- `haproxy` and `postgresql` external modules do not yet expose a `machines` param; comments note this

Fixes #151

Jira: https://warthogs.atlassian.net/browse/LNDENG-4669