### PR TITLE
fix: install `landscape-hosted` deb when not in standalone mode

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -778,6 +778,28 @@ class LandscapeServerCharm(CharmBase):
     def _on_upgrade_charm(self, _: UpgradeCharmEvent) -> None:
         self._provide_all_haproxy_route_requirements()
 
+    def _install_debian_packages_with_recommends(
+        self, package_names: list[str]
+    ) -> None:
+        """
+        Installs a Debian package via apt with `--install-recommends`.
+        """
+
+        # Explicitly ensure cache is up-to-date after adding the PPA.
+        try:
+            apt.add_package(package_names, update_cache=True)
+        except PackageError as e:
+            logger.error("Failed to install packages: %s", str(e))
+            raise e
+
+    def _hold_debian_packages(self, package_names: list[str]) -> None:
+        for p in package_names:
+            try:
+                check_call(["apt-mark", "hold", p])
+            except CalledProcessError as e:
+                logger.error("Error trying to hold %s: %s", p, str(e))
+                raise e
+
     def _on_install(self, event: InstallEvent) -> None:
         """Handle the install event."""
         self.unit.status = MaintenanceStatus("Installing apt packages")
@@ -811,7 +833,6 @@ class LandscapeServerCharm(CharmBase):
         # least any juju_proxy setting, add the classic http(s)_proxy to the env
         # that will be used only for add-apt-repository call
         add_apt_repository_env = self._build_add_apt_repository_env()
-        pkg_list = [LANDSCAPE_SERVER]
         for ppa in self.charm_config.landscape_ppas:
             try:
                 check_call(
@@ -821,41 +842,23 @@ class LandscapeServerCharm(CharmBase):
                 logger.error("Failed to add PPA '%s': %s", ppa, str(e))
                 raise e
 
-        if self.charm_config.min_install:
-            logger.info("Not installing hashids..")
-            try:
-                check_call(
-                    [
-                        "apt",
-                        "install",
-                        LANDSCAPE_SERVER,
-                        "--no-install-recommends",
-                        "-y",
-                    ]
-                )
-            except CalledProcessError as e:
-                logger.error("Failed to install %s: %s", LANDSCAPE_SERVER, str(e))
-                raise e
-        else:
-            pkg_list.append(LANDSCAPE_HASH_IDS)
+        install_list = [LANDSCAPE_SERVER]
+        if not self.charm_config.min_install:
+            install_list.append(LANDSCAPE_HASH_IDS)
+        if self.charm_config.deployment_mode != "standalone":
+            install_list.append(LANDSCAPE_HOSTED)
 
-        deployment_mode = self.charm_config.deployment_mode
-        if deployment_mode != "standalone":
-            pkg_list.append(LANDSCAPE_HOSTED)
+        # Only hold packages that were explicitly installed (not recommends-pulled-in).
+        # When min_install=True, landscape-hosted is installed but not held because
+        # it pulled in as a package, not a controlled dependency.
+        hold_list = [LANDSCAPE_SERVER]
+        if not self.charm_config.min_install:
+            if self.charm_config.deployment_mode != "standalone":
+                hold_list.append(LANDSCAPE_HOSTED)
+            hold_list.append(LANDSCAPE_HASH_IDS)
 
-        # Explicitly ensure cache is up-to-date after adding the PPA.
-        try:
-            apt.add_package(pkg_list, update_cache=True)
-        except PackageError as e:
-            logger.error("Failed to install packages: %s", str(e))
-            raise e
-
-        for p in pkg_list:
-            try:
-                check_call(["apt-mark", "hold", p])
-            except CalledProcessError as e:
-                logger.error("Error trying to hold %s: %s", p, str(e))
-                raise e
+        self._install_debian_packages_with_recommends(install_list)
+        self._hold_debian_packages(hold_list)
 
         self.unit.status = MaintenanceStatus("Installing landscape-outbox snap")
         try:

--- a/src/charm.py
+++ b/src/charm.py
@@ -842,23 +842,27 @@ class LandscapeServerCharm(CharmBase):
                 logger.error("Failed to add PPA '%s': %s", ppa, str(e))
                 raise e
 
-        install_list = [LANDSCAPE_SERVER]
-        if not self.charm_config.min_install:
-            install_list.append(LANDSCAPE_HASH_IDS)
-        if self.charm_config.deployment_mode != "standalone":
-            install_list.append(LANDSCAPE_HOSTED)
-
-        # Only hold packages that were explicitly installed (not recommends-pulled-in).
-        # When min_install=True, landscape-hosted is installed but not held because
-        # it pulled in as a package, not a controlled dependency.
-        hold_list = [LANDSCAPE_SERVER]
-        if not self.charm_config.min_install:
+        if self.charm_config.min_install:
+            try:
+                check_call(
+                    [
+                        "apt-get",
+                        "install",
+                        "--no-install-recommends",
+                        "-y",
+                        LANDSCAPE_SERVER,
+                    ]
+                )
+            except CalledProcessError as e:
+                logger.error("Failed to install %s: %s", LANDSCAPE_SERVER, str(e))
+                raise e
+            self._hold_debian_packages([LANDSCAPE_SERVER])
+        else:
+            pkg_list = [LANDSCAPE_SERVER, LANDSCAPE_HASH_IDS]
             if self.charm_config.deployment_mode != "standalone":
-                hold_list.append(LANDSCAPE_HOSTED)
-            hold_list.append(LANDSCAPE_HASH_IDS)
-
-        self._install_debian_packages_with_recommends(install_list)
-        self._hold_debian_packages(hold_list)
+                pkg_list.append(LANDSCAPE_HOSTED)
+            self._install_debian_packages_with_recommends(pkg_list)
+            self._hold_debian_packages(pkg_list)
 
         self.unit.status = MaintenanceStatus("Installing landscape-outbox snap")
         try:

--- a/src/charm.py
+++ b/src/charm.py
@@ -811,7 +811,6 @@ class LandscapeServerCharm(CharmBase):
         # least any juju_proxy setting, add the classic http(s)_proxy to the env
         # that will be used only for add-apt-repository call
         add_apt_repository_env = self._build_add_apt_repository_env()
-        apt_mark_hold_list = [LANDSCAPE_SERVER]
         pkg_list = [LANDSCAPE_SERVER]
         for ppa in self.charm_config.landscape_ppas:
             try:
@@ -839,12 +838,10 @@ class LandscapeServerCharm(CharmBase):
                 raise e
         else:
             pkg_list.append(LANDSCAPE_HASH_IDS)
-            apt_mark_hold_list.append(LANDSCAPE_HASH_IDS)
 
         deployment_mode = self.charm_config.deployment_mode
         if deployment_mode != "standalone":
             pkg_list.append(LANDSCAPE_HOSTED)
-            apt_mark_hold_list.append(LANDSCAPE_HOSTED)
 
         # Explicitly ensure cache is up-to-date after adding the PPA.
         try:
@@ -853,11 +850,11 @@ class LandscapeServerCharm(CharmBase):
             logger.error("Failed to install packages: %s", str(e))
             raise e
 
-        for p in apt_mark_hold_list:
+        for p in pkg_list:
             try:
                 check_call(["apt-mark", "hold", p])
             except CalledProcessError as e:
-                logger.error("failed trying to hold %s: %s", p, str(e))
+                logger.error("Error trying to hold %s: %s", p, str(e))
                 raise e
 
         self.unit.status = MaintenanceStatus("Installing landscape-outbox snap")

--- a/src/charm.py
+++ b/src/charm.py
@@ -111,6 +111,8 @@ GPG_SERVICE_CONF_SECTIONS = (
 )
 
 LANDSCAPE_SERVER = "landscape-server"
+LANDSCAPE_HASH_IDS = "landscape-hashids"
+LANDSCAPE_HOSTED = "landscape-hosted"
 LANDSCAPE_PACKAGES = (
     LANDSCAPE_SERVER,
     "landscape-client",
@@ -488,9 +490,9 @@ class LandscapeServerCharm(CharmBase):
         self._set_ports()
 
         # Update additional configuration
-        update_service_conf(
-            {"global": {"deployment-mode": self.charm_config.deployment_mode}}
-        )
+        update_service_conf({
+            "global": {"deployment-mode": self.charm_config.deployment_mode}
+        })
         configure_for_deployment_mode(self.charm_config.deployment_mode)
         write_deployment_mode_systemd_override(self.charm_config.deployment_mode)
 
@@ -587,9 +589,9 @@ class LandscapeServerCharm(CharmBase):
                 logger.info("Generating new random cookie encryption key")
                 cookie_encryption_key = generate_cookie_encryption_key()
                 peer_relation = self.model.get_relation("replicas")
-                peer_relation.data[self.app].update(
-                    {"cookie-encryption-key": cookie_encryption_key}
-                )
+                peer_relation.data[self.app].update({
+                    "cookie-encryption-key": cookie_encryption_key
+                })
 
         secret_token_changed = (
             secret_token and secret_token != self._stored.secret_token
@@ -799,40 +801,61 @@ class LandscapeServerCharm(CharmBase):
         try:
             # This package is responsible for the hanging installs and ignores env vars
             apt.remove_package(["needrestart"])
+        except (PackageNotFoundError, PackageError) as e:
+            logger.error("Failed to remove needrestart package: %s", str(e))
+            raise e  # This will trigger juju's exponential retry
 
-            # Add the Landscape Server PPA and install via apt.
-            # add-apt-repository doesn't use the proxy configuration from apt or juju
-            # let's make sure to use the http(s) proxy settings from the charm or at
-            # least any juju_proxy setting, add the classic http(s)_proxy to the env
-            # that will be used only for add-apt-repository call
-            add_apt_repository_env = self._build_add_apt_repository_env()
-
-            for ppa in self.charm_config.landscape_ppas:
+        # Add the Landscape Server PPA and install via apt.
+        # add-apt-repository doesn't use the proxy configuration from apt or juju
+        # let's make sure to use the http(s) proxy settings from the charm or at
+        # least any juju_proxy setting, add the classic http(s)_proxy to the env
+        # that will be used only for add-apt-repository call
+        add_apt_repository_env = self._build_add_apt_repository_env()
+        apt_mark_hold_list = [LANDSCAPE_SERVER]
+        pkg_list = [LANDSCAPE_SERVER]
+        for ppa in self.charm_config.landscape_ppas:
+            try:
                 check_call(
                     ["add-apt-repository", "-y", ppa], env=add_apt_repository_env
                 )
+            except CalledProcessError as e:
+                logger.error("Failed to add PPA '%s': %s", ppa, str(e))
+                raise e
 
-            if self.charm_config.min_install:
-                logger.info("Not installing hashids..")
-                check_call(
-                    [
-                        "apt",
-                        "install",
-                        LANDSCAPE_SERVER,
-                        "--no-install-recommends",
-                        "-y",
-                    ]
-                )
-            else:
-                # Explicitly ensure cache is up-to-date after adding the PPA.
-                apt.add_package(
-                    [LANDSCAPE_SERVER, "landscape-hashids"], update_cache=True
-                )
-                check_call(["apt-mark", "hold", "landscape-hashids"])
-            check_call(["apt-mark", "hold", LANDSCAPE_SERVER])
-        except (PackageNotFoundError, PackageError, CalledProcessError) as exc:
-            logger.error("Failed to install packages")
-            raise exc  # This will trigger juju's exponential retry
+        if self.charm_config.min_install:
+            logger.info("Not installing hashids..")
+            try:
+                check_call([
+                    "apt",
+                    "install",
+                    LANDSCAPE_SERVER,
+                    "--no-install-recommends",
+                    "-y",
+                ])
+            except CalledProcessError as e:
+                logger.error("Failed to install %s: %s", LANDSCAPE_SERVER, str(e))
+                raise e
+        else:
+            pkg_list.append(LANDSCAPE_HASH_IDS)
+            apt_mark_hold_list.append(LANDSCAPE_HASH_IDS)
+
+        deployment_mode = self.charm_config.deployment_mode
+        if deployment_mode != "standalone":
+            pkg_list.append(LANDSCAPE_HOSTED)
+            apt_mark_hold_list.append(LANDSCAPE_HOSTED)
+
+        # Explicitly ensure cache is up-to-date after adding the PPA.
+        try:
+            apt.add_package(pkg_list, update_cache=True)
+        except PackageError as e:
+            logger.error("Failed to install packages: %s", str(e))
+
+        for p in apt_mark_hold_list:
+            try:
+                check_call(["apt-mark", "hold", p])
+            except CalledProcessError as e:
+                logger.error("failed trying to hold %s: %s", p, str(e))
+                raise e
 
         self.unit.status = MaintenanceStatus("Installing landscape-outbox snap")
         try:
@@ -897,23 +920,19 @@ class LandscapeServerCharm(CharmBase):
         deployment_mode = self.charm_config.deployment_mode
         is_standalone = deployment_mode == "standalone"
 
-        update_default_settings(
-            {
-                "RUN_ALL": "no",
-                "RUN_APISERVER": str(self.charm_config.worker_counts),
-                "RUN_ASYNC_FRONTEND": "yes",
-                "RUN_JOBHANDLER": "yes",
-                "RUN_APPSERVER": str(self.charm_config.worker_counts),
-                "RUN_MSGSERVER": str(self.charm_config.worker_counts),
-                "RUN_PINGSERVER": str(self.charm_config.worker_counts),
-                "RUN_CRON": "yes" if is_leader else "no",
-                "RUN_PACKAGESEARCH": "yes" if is_leader else "no",
-                "RUN_PACKAGEUPLOADSERVER": (
-                    "yes" if is_leader and is_standalone else "no"
-                ),
-                "RUN_PPPA_PROXY": "no",
-            }
-        )
+        update_default_settings({
+            "RUN_ALL": "no",
+            "RUN_APISERVER": str(self.charm_config.worker_counts),
+            "RUN_ASYNC_FRONTEND": "yes",
+            "RUN_JOBHANDLER": "yes",
+            "RUN_APPSERVER": str(self.charm_config.worker_counts),
+            "RUN_MSGSERVER": str(self.charm_config.worker_counts),
+            "RUN_PINGSERVER": str(self.charm_config.worker_counts),
+            "RUN_CRON": "yes" if is_leader else "no",
+            "RUN_PACKAGESEARCH": "yes" if is_leader else "no",
+            "RUN_PACKAGEUPLOADSERVER": ("yes" if is_leader and is_standalone else "no"),
+            "RUN_PPPA_PROXY": "no",
+        })
 
         logger.info("Starting services")
 
@@ -1236,12 +1255,10 @@ class LandscapeServerCharm(CharmBase):
         self._stored.ready[relation_name] = False
         self.unit.status = MaintenanceStatus(f"Setting up {relation_name} connection")
 
-        event.relation.data[self.unit].update(
-            {
-                "username": AMQP_USERNAME,
-                "vhost": VHOSTS[relation_name],
-            }
-        )
+        event.relation.data[self.unit].update({
+            "username": AMQP_USERNAME,
+            "vhost": VHOSTS[relation_name],
+        })
 
     def _amqp_relation_changed(self, event):
         unit_data = event.relation.data[event.unit]
@@ -1268,14 +1285,12 @@ class LandscapeServerCharm(CharmBase):
             )
             return
 
-        update_service_conf(
-            {
-                "broker": {
-                    "host": hostname,
-                    "password": password,
-                }
+        update_service_conf({
+            "broker": {
+                "host": hostname,
+                "password": password,
             }
-        )
+        })
 
         self.unit.status = ActiveStatus("Unit is ready")
         self._update_ready_status()
@@ -1447,11 +1462,9 @@ class LandscapeServerCharm(CharmBase):
             },
         }
 
-        relation.data[self.unit].update(
-            {
-                "monitors": yaml.safe_dump(monitors),
-            }
-        )
+        relation.data[self.unit].update({
+            "monitors": yaml.safe_dump(monitors),
+        })
 
         if not os.path.exists(NRPE_D_DIR):
             logger.debug("NRPE directories not ready")
@@ -1508,15 +1521,13 @@ command[check_{service}]=/usr/local/lib/nagios/plugins/check_systemd.py {service
         else:
             icon_data = None
 
-        event.relation.data[self.app].update(
-            {
-                "name": "Landscape",
-                "url": root_url,
-                "subtitle": subtitle,
-                "group": group,
-                "icon": icon_data,
-            }
-        )
+        event.relation.data[self.app].update({
+            "name": "Landscape",
+            "url": root_url,
+            "subtitle": subtitle,
+            "group": group,
+            "icon": icon_data,
+        })
 
     def _update_debarchive_relations(
         self, notify_secret_token_changed: bool = False
@@ -1592,13 +1603,11 @@ command[check_{service}]=/usr/local/lib/nagios/plugins/check_systemd.py {service
             ip = str(self.model.get_binding(peer_relation).network.bind_address)
             peer_relation.data[self.app].update({"leader-ip": ip})
 
-            update_service_conf(
-                {
-                    "package-search": {
-                        "host": "localhost",
-                    },
-                }
-            )
+            update_service_conf({
+                "package-search": {
+                    "host": "localhost",
+                },
+            })
 
             # Now that we (may) have a leader IP, refresh any debarchive
             # relations that depend on it for their root URL fallback.
@@ -1619,13 +1628,11 @@ command[check_{service}]=/usr/local/lib/nagios/plugins/check_systemd.py {service
             leader_ip = peer_relation.data[self.app].get("leader-ip")
 
             if leader_ip:
-                update_service_conf(
-                    {
-                        "package-search": {
-                            "host": leader_ip,
-                        },
-                    }
-                )
+                update_service_conf({
+                    "package-search": {
+                        "host": leader_ip,
+                    },
+                })
 
         self._leader_changed()
 
@@ -1677,13 +1684,11 @@ command[check_{service}]=/usr/local/lib/nagios/plugins/check_systemd.py {service
 
         if not self.unit.is_leader():
             if leader_ip_value:
-                update_service_conf(
-                    {
-                        "package-search": {
-                            "host": leader_ip_value,
-                        },
-                    }
-                )
+                update_service_conf({
+                    "package-search": {
+                        "host": leader_ip_value,
+                    },
+                })
 
         self._leader_changed()
 
@@ -1796,14 +1801,12 @@ command[check_{service}]=/usr/local/lib/nagios/plugins/check_systemd.py {service
             return
 
         self.unit.status = MaintenanceStatus("Configuring OpenID")
-        update_service_conf(
-            {
-                "landscape": {
-                    "openid-provider-url": self.charm_config.openid_provider_url,
-                    "openid-logout-url": self.charm_config.openid_logout_url,
-                },
-            }
-        )
+        update_service_conf({
+            "landscape": {
+                "openid-provider-url": self.charm_config.openid_provider_url,
+                "openid-logout-url": self.charm_config.openid_logout_url,
+            },
+        })
         self.unit.status = WaitingStatus("Waiting on relations")
 
     def _bootstrap_account(self):

--- a/src/charm.py
+++ b/src/charm.py
@@ -490,9 +490,9 @@ class LandscapeServerCharm(CharmBase):
         self._set_ports()
 
         # Update additional configuration
-        update_service_conf({
-            "global": {"deployment-mode": self.charm_config.deployment_mode}
-        })
+        update_service_conf(
+            {"global": {"deployment-mode": self.charm_config.deployment_mode}}
+        )
         configure_for_deployment_mode(self.charm_config.deployment_mode)
         write_deployment_mode_systemd_override(self.charm_config.deployment_mode)
 
@@ -589,9 +589,9 @@ class LandscapeServerCharm(CharmBase):
                 logger.info("Generating new random cookie encryption key")
                 cookie_encryption_key = generate_cookie_encryption_key()
                 peer_relation = self.model.get_relation("replicas")
-                peer_relation.data[self.app].update({
-                    "cookie-encryption-key": cookie_encryption_key
-                })
+                peer_relation.data[self.app].update(
+                    {"cookie-encryption-key": cookie_encryption_key}
+                )
 
         secret_token_changed = (
             secret_token and secret_token != self._stored.secret_token
@@ -825,13 +825,15 @@ class LandscapeServerCharm(CharmBase):
         if self.charm_config.min_install:
             logger.info("Not installing hashids..")
             try:
-                check_call([
-                    "apt",
-                    "install",
-                    LANDSCAPE_SERVER,
-                    "--no-install-recommends",
-                    "-y",
-                ])
+                check_call(
+                    [
+                        "apt",
+                        "install",
+                        LANDSCAPE_SERVER,
+                        "--no-install-recommends",
+                        "-y",
+                    ]
+                )
             except CalledProcessError as e:
                 logger.error("Failed to install %s: %s", LANDSCAPE_SERVER, str(e))
                 raise e
@@ -849,6 +851,7 @@ class LandscapeServerCharm(CharmBase):
             apt.add_package(pkg_list, update_cache=True)
         except PackageError as e:
             logger.error("Failed to install packages: %s", str(e))
+            raise e
 
         for p in apt_mark_hold_list:
             try:
@@ -920,19 +923,23 @@ class LandscapeServerCharm(CharmBase):
         deployment_mode = self.charm_config.deployment_mode
         is_standalone = deployment_mode == "standalone"
 
-        update_default_settings({
-            "RUN_ALL": "no",
-            "RUN_APISERVER": str(self.charm_config.worker_counts),
-            "RUN_ASYNC_FRONTEND": "yes",
-            "RUN_JOBHANDLER": "yes",
-            "RUN_APPSERVER": str(self.charm_config.worker_counts),
-            "RUN_MSGSERVER": str(self.charm_config.worker_counts),
-            "RUN_PINGSERVER": str(self.charm_config.worker_counts),
-            "RUN_CRON": "yes" if is_leader else "no",
-            "RUN_PACKAGESEARCH": "yes" if is_leader else "no",
-            "RUN_PACKAGEUPLOADSERVER": ("yes" if is_leader and is_standalone else "no"),
-            "RUN_PPPA_PROXY": "no",
-        })
+        update_default_settings(
+            {
+                "RUN_ALL": "no",
+                "RUN_APISERVER": str(self.charm_config.worker_counts),
+                "RUN_ASYNC_FRONTEND": "yes",
+                "RUN_JOBHANDLER": "yes",
+                "RUN_APPSERVER": str(self.charm_config.worker_counts),
+                "RUN_MSGSERVER": str(self.charm_config.worker_counts),
+                "RUN_PINGSERVER": str(self.charm_config.worker_counts),
+                "RUN_CRON": "yes" if is_leader else "no",
+                "RUN_PACKAGESEARCH": "yes" if is_leader else "no",
+                "RUN_PACKAGEUPLOADSERVER": (
+                    "yes" if is_leader and is_standalone else "no"
+                ),
+                "RUN_PPPA_PROXY": "no",
+            }
+        )
 
         logger.info("Starting services")
 
@@ -1255,10 +1262,12 @@ class LandscapeServerCharm(CharmBase):
         self._stored.ready[relation_name] = False
         self.unit.status = MaintenanceStatus(f"Setting up {relation_name} connection")
 
-        event.relation.data[self.unit].update({
-            "username": AMQP_USERNAME,
-            "vhost": VHOSTS[relation_name],
-        })
+        event.relation.data[self.unit].update(
+            {
+                "username": AMQP_USERNAME,
+                "vhost": VHOSTS[relation_name],
+            }
+        )
 
     def _amqp_relation_changed(self, event):
         unit_data = event.relation.data[event.unit]
@@ -1285,12 +1294,14 @@ class LandscapeServerCharm(CharmBase):
             )
             return
 
-        update_service_conf({
-            "broker": {
-                "host": hostname,
-                "password": password,
+        update_service_conf(
+            {
+                "broker": {
+                    "host": hostname,
+                    "password": password,
+                }
             }
-        })
+        )
 
         self.unit.status = ActiveStatus("Unit is ready")
         self._update_ready_status()
@@ -1462,9 +1473,11 @@ class LandscapeServerCharm(CharmBase):
             },
         }
 
-        relation.data[self.unit].update({
-            "monitors": yaml.safe_dump(monitors),
-        })
+        relation.data[self.unit].update(
+            {
+                "monitors": yaml.safe_dump(monitors),
+            }
+        )
 
         if not os.path.exists(NRPE_D_DIR):
             logger.debug("NRPE directories not ready")
@@ -1521,13 +1534,15 @@ command[check_{service}]=/usr/local/lib/nagios/plugins/check_systemd.py {service
         else:
             icon_data = None
 
-        event.relation.data[self.app].update({
-            "name": "Landscape",
-            "url": root_url,
-            "subtitle": subtitle,
-            "group": group,
-            "icon": icon_data,
-        })
+        event.relation.data[self.app].update(
+            {
+                "name": "Landscape",
+                "url": root_url,
+                "subtitle": subtitle,
+                "group": group,
+                "icon": icon_data,
+            }
+        )
 
     def _update_debarchive_relations(
         self, notify_secret_token_changed: bool = False
@@ -1603,11 +1618,13 @@ command[check_{service}]=/usr/local/lib/nagios/plugins/check_systemd.py {service
             ip = str(self.model.get_binding(peer_relation).network.bind_address)
             peer_relation.data[self.app].update({"leader-ip": ip})
 
-            update_service_conf({
-                "package-search": {
-                    "host": "localhost",
-                },
-            })
+            update_service_conf(
+                {
+                    "package-search": {
+                        "host": "localhost",
+                    },
+                }
+            )
 
             # Now that we (may) have a leader IP, refresh any debarchive
             # relations that depend on it for their root URL fallback.
@@ -1628,11 +1645,13 @@ command[check_{service}]=/usr/local/lib/nagios/plugins/check_systemd.py {service
             leader_ip = peer_relation.data[self.app].get("leader-ip")
 
             if leader_ip:
-                update_service_conf({
-                    "package-search": {
-                        "host": leader_ip,
-                    },
-                })
+                update_service_conf(
+                    {
+                        "package-search": {
+                            "host": leader_ip,
+                        },
+                    }
+                )
 
         self._leader_changed()
 
@@ -1684,11 +1703,13 @@ command[check_{service}]=/usr/local/lib/nagios/plugins/check_systemd.py {service
 
         if not self.unit.is_leader():
             if leader_ip_value:
-                update_service_conf({
-                    "package-search": {
-                        "host": leader_ip_value,
-                    },
-                })
+                update_service_conf(
+                    {
+                        "package-search": {
+                            "host": leader_ip_value,
+                        },
+                    }
+                )
 
         self._leader_changed()
 
@@ -1801,12 +1822,14 @@ command[check_{service}]=/usr/local/lib/nagios/plugins/check_systemd.py {service
             return
 
         self.unit.status = MaintenanceStatus("Configuring OpenID")
-        update_service_conf({
-            "landscape": {
-                "openid-provider-url": self.charm_config.openid_provider_url,
-                "openid-logout-url": self.charm_config.openid_logout_url,
-            },
-        })
+        update_service_conf(
+            {
+                "landscape": {
+                    "openid-provider-url": self.charm_config.openid_provider_url,
+                    "openid-logout-url": self.charm_config.openid_logout_url,
+                },
+            }
+        )
         self.unit.status = WaitingStatus("Waiting on relations")
 
     def _bootstrap_account(self):

--- a/src/config.py
+++ b/src/config.py
@@ -143,18 +143,12 @@ class LandscapeCharmConfiguration(BaseModel):
         return self
 
     @model_validator(mode="after")
-    def oidc_minimum_fields(self):
-        """
-        If providing any of `oidc_issuer`, `oidc_client_id`, or `oidc_client_secret`,
-        must provide all three.
-        """
-        required_configs = ("oidc_issuer", "oidc_client_id", "oidc_client_secret")
-        fields = self.model_dump(include=set(required_configs))
-
-        if any(fields.values()) and not all(fields.values()):
+    def check_deployment_mode_min_install(self):
+        """min_install is only valid with standalone deployments."""
+        if self.min_install and self.deployment_mode != "standalone":
             raise ValueError(
-                f"When using OIDC, must provide all of {required_configs}. "
-                f"Got {fields}."
+                f"min_install=True is not compatible with "
+                f"deployment_mode={self.deployment_mode!r}."
             )
         return self
 
@@ -186,6 +180,22 @@ class LandscapeCharmConfiguration(BaseModel):
                 f"the following ports: {', '.join(map(str, overused_ports))}"
             )
 
+        return self
+
+    @model_validator(mode="after")
+    def oidc_minimum_fields(self):
+        """
+        If providing any of `oidc_issuer`, `oidc_client_id`, or `oidc_client_secret`,
+        must provide all three.
+        """
+        required_configs = ("oidc_issuer", "oidc_client_id", "oidc_client_secret")
+        fields = self.model_dump(include=set(required_configs))
+
+        if any(fields.values()) and not all(fields.values()):
+            raise ValueError(
+                f"When using OIDC, must provide all of {required_configs}. "
+                f"Got {fields}."
+            )
         return self
 
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -61,6 +61,7 @@ from charm import (
     UPDATE_WSL_DISTRIBUTIONS_SCRIPT,
 )
 from settings_files import AMQP_USERNAME, VHOSTS
+from src.charm import LANDSCAPE_HASH_IDS, LANDSCAPE_HOSTED, LANDSCAPE_SERVER
 
 IS_CI = os.getenv("GITHUB_ACTIONS", None) is not None
 """
@@ -1268,7 +1269,7 @@ class TestCharm(unittest.TestCase):
         )
         mocks["check_call"].assert_any_call(["apt-mark", "hold", "landscape-server"])
         mocks["apt"].add_package.assert_called_once_with(
-            ["landscape-server", "landscape-hashids"],
+            ["landscape-server", LANDSCAPE_HASH_IDS],
             update_cache=True,
         )
         mocks["snap"].add.assert_called_once_with(
@@ -3264,13 +3265,13 @@ class TestPackageInstall:
             ctx.run(ctx.on.install(), state)
 
         apt_mock.add_package.assert_called_once_with(
-            ["landscape-server"], update_cache=True
+            [LANDSCAPE_SERVER], update_cache=True
         )
 
     def test_install_landscape_server_hashids(self):
         """
         When passing `min_install=false` and running in standalone mode,
-        only the landscape-server package is installed.
+        the landscape-server and landscape-hashids packages are installed.
         """
         ctx = Context(LandscapeServerCharm)
         state = State(
@@ -3291,13 +3292,13 @@ class TestPackageInstall:
             ctx.run(ctx.on.install(), state)
 
         apt_mock.add_package.assert_called_once_with(
-            ["landscape-server", "landscape-hashids"], update_cache=True
+            [LANDSCAPE_SERVER, LANDSCAPE_HASH_IDS], update_cache=True
         )
 
     def test_install_landscape_server_hashids_hosted(self):
         """
         When passing `min_install=false` and running in SaaS mode,
-        only the landscape-server package is installed.
+        only the all three packages are installed.
         """
         ctx = Context(LandscapeServerCharm)
         state = State(
@@ -3318,14 +3319,14 @@ class TestPackageInstall:
             ctx.run(ctx.on.install(), state)
 
         apt_mock.add_package.assert_called_once_with(
-            ["landscape-server", "landscape-hashids", "landscape-hosted"],
+            [LANDSCAPE_SERVER, LANDSCAPE_HASH_IDS, LANDSCAPE_HOSTED],
             update_cache=True,
         )
 
     def test_install_landscape_server_hosted(self):
         """
-        When passing `min_install=false` and running in SaaS mode,
-        only the landscape-server package is installed.
+        When passing `min_install=true` and running in SaaS mode,
+        the landscape-server and landscape-hosted packages are installed.
         """
         ctx = Context(LandscapeServerCharm)
         state = State(
@@ -3346,6 +3347,6 @@ class TestPackageInstall:
             ctx.run(ctx.on.install(), state)
 
         apt_mock.add_package.assert_called_once_with(
-            ["landscape-server", "landscape-hosted"],
+            [LANDSCAPE_SERVER, LANDSCAPE_HOSTED],
             update_cache=True,
         )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -4,7 +4,6 @@
 # Learn more about testing at
 # https://documentation.ubuntu.com/ops/latest/explanation/testing/
 
-import logging
 from grp import struct_group
 import json
 import os
@@ -1399,11 +1398,13 @@ class TestCharm(unittest.TestCase):
     ):
         root_url = "https://landscape.local/"
         system_email = "landscape-devel@lists.canonical.com"
-        self.harness.update_config({
-            "deployment_mode": "standalone",
-            "root_url": root_url,
-            "system_email": system_email,
-        })
+        self.harness.update_config(
+            {
+                "deployment_mode": "standalone",
+                "root_url": root_url,
+                "system_email": system_email,
+            }
+        )
 
         with (
             patch("charm.check_call") as check_call_mock,
@@ -1443,11 +1444,13 @@ class TestCharm(unittest.TestCase):
 
     @patch("charm.get_modified_env_vars", return_value={"PATH": "/usr/bin"})
     def test_migrate_schema_bootstrap_override_args(self, get_env):
-        self.harness.update_config({
-            "bootstrap_schema_override_args": (
-                "--with-openstack,--with-extra-computers,10"
-            )
-        })
+        self.harness.update_config(
+            {
+                "bootstrap_schema_override_args": (
+                    "--with-openstack,--with-extra-computers,10"
+                )
+            }
+        )
 
         with (
             patch("charm.check_call") as check_call_mock,
@@ -1589,9 +1592,9 @@ class TestCharm(unittest.TestCase):
     def test_update_ready_status_not_running(self):
         self.harness.charm.unit.status = WaitingStatus()
 
-        self.harness.charm._stored.ready.update({
-            k: True for k in self.harness.charm._stored.ready.keys()
-        })
+        self.harness.charm._stored.ready.update(
+            {k: True for k in self.harness.charm._stored.ready.keys()}
+        )
 
         patches = patch.multiple(
             "charm",
@@ -1613,9 +1616,9 @@ class TestCharm(unittest.TestCase):
     def test_update_ready_status_running(self):
         self.harness.charm.unit.status = WaitingStatus()
 
-        self.harness.charm._stored.ready.update({
-            k: True for k in self.harness.charm._stored.ready.keys()
-        })
+        self.harness.charm._stored.ready.update(
+            {k: True for k in self.harness.charm._stored.ready.keys()}
+        )
         self.harness.charm._stored.running = True
 
         self.harness.charm._update_ready_status()
@@ -1627,9 +1630,9 @@ class TestCharm(unittest.TestCase):
     def test_update_ready_status_called_process_error(self):
         self.harness.charm.unit.status = WaitingStatus()
 
-        self.harness.charm._stored.ready.update({
-            k: True for k in self.harness.charm._stored.ready.keys()
-        })
+        self.harness.charm._stored.ready.update(
+            {k: True for k in self.harness.charm._stored.ready.keys()}
+        )
 
         patches = patch.multiple(
             "charm",
@@ -1701,16 +1704,18 @@ class TestCharm(unittest.TestCase):
         self.assertIsInstance(status, BlockedStatus)
         self.assertFalse(self.harness.charm._stored.ready["db"])
 
-        update_service_conf_mock.assert_called_once_with({
-            "stores": {
-                "host": "1.2.3.4:5678",
-                "password": "testpass",
-            },
-            "schema": {
-                "store_user": "testuser",
-                "store_password": "testpass",
-            },
-        })
+        update_service_conf_mock.assert_called_once_with(
+            {
+                "stores": {
+                    "host": "1.2.3.4:5678",
+                    "password": "testpass",
+                },
+                "schema": {
+                    "store_user": "testuser",
+                    "store_password": "testpass",
+                },
+            }
+        )
 
     @patch("charm.update_service_conf")
     def test_on_manual_db_config_change(self, _):
@@ -1750,11 +1755,13 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(update_service_conf_mock.call_count, 2)
         self.assertEqual(
             update_service_conf_mock.call_args_list[1],
-            call({
-                "stores": {
-                    "host": "hello:world",
-                },
-            }),
+            call(
+                {
+                    "stores": {
+                        "host": "hello:world",
+                    },
+                }
+            ),
         )
 
     @patch("charm.update_service_conf")
@@ -1948,12 +1955,14 @@ class TestCharm(unittest.TestCase):
         self.assertTrue(self.harness.charm._stored.ready["inbound-amqp"])
         self.assertTrue(self.harness.charm._stored.ready["outbound-amqp"])
 
-        mock_update_conf.assert_called_once_with({
-            "broker": {
-                "host": ",".join(hostname),
-                "password": password,
-            },
-        })
+        mock_update_conf.assert_called_once_with(
+            {
+                "broker": {
+                    "host": ",".join(hostname),
+                    "password": password,
+                },
+            }
+        )
 
     def test_amqp_relation_changed_outbound_first(self):
         """
@@ -1990,12 +1999,14 @@ class TestCharm(unittest.TestCase):
         self.assertTrue(self.harness.charm._stored.ready["inbound-amqp"])
         self.assertTrue(self.harness.charm._stored.ready["outbound-amqp"])
 
-        mock_update_conf.assert_called_once_with({
-            "broker": {
-                "host": hostname,
-                "password": password,
-            },
-        })
+        mock_update_conf.assert_called_once_with(
+            {
+                "broker": {
+                    "host": hostname,
+                    "password": password,
+                },
+            }
+        )
 
     def test_configure_smtp_relay_host(self):
         mock_postfix_cf = os.path.join(self.tempdir.name, "my_postfix.cf")
@@ -2395,11 +2406,13 @@ class TestCharm(unittest.TestCase):
             )
 
         self.harness.charm._update_nrpe_checks.assert_called_once()
-        mock_update_conf.assert_called_once_with({
-            "package-search": {
-                "host": "localhost",
-            },
-        })
+        mock_update_conf.assert_called_once_with(
+            {
+                "package-search": {
+                    "host": "localhost",
+                },
+            }
+        )
 
     def test_on_replicas_relation_changed_non_leader(self):
         """
@@ -2419,11 +2432,13 @@ class TestCharm(unittest.TestCase):
             )
 
         self.harness.charm._update_nrpe_checks.assert_called_once()
-        mock_update_conf.assert_called_once_with({
-            "package-search": {
-                "host": "test",
-            },
-        })
+        mock_update_conf.assert_called_once_with(
+            {
+                "package-search": {
+                    "host": "test",
+                },
+            }
+        )
 
 
 class TestMultiplePPAs:
@@ -2532,10 +2547,12 @@ class TestBootstrapAccount(unittest.TestCase):
 
     @patch("charm.update_service_conf")
     def test_bootstrap_account_doesnt_run_with_missing_configs(self, _):
-        self.harness.update_config({
-            "admin_email": "hello@ubuntu.com",
-            "admin_name": "Hello Ubuntu",
-        })
+        self.harness.update_config(
+            {
+                "admin_email": "hello@ubuntu.com",
+                "admin_name": "Hello Ubuntu",
+            }
+        )
         self.log_mock.assert_any_call(
             "Admin email, name, and password required for bootstrap account"
         )
@@ -2543,34 +2560,40 @@ class TestBootstrapAccount(unittest.TestCase):
 
     @patch("charm.update_service_conf")
     def test_bootstrap_account_password_redacted(self, _):
-        self.harness.update_config({
-            "admin_email": "hello@ubuntu.com",
-            "admin_name": "Hello Ubuntu",
-            "admin_password": "secret123",
-            "registration_key": "secret123",
-            "root_url": "https://www.landscape.com",
-        })
+        self.harness.update_config(
+            {
+                "admin_email": "hello@ubuntu.com",
+                "admin_name": "Hello Ubuntu",
+                "admin_password": "secret123",
+                "registration_key": "secret123",
+                "root_url": "https://www.landscape.com",
+            }
+        )
         for mock_call in self.log_info_mock.call_args_list:
             self.assertNotIn("secret123", str(mock_call.args))
 
     @patch("charm.update_service_conf")
     def test_bootstrap_account_skips_when_no_root_url_and_no_leader_ip(self, _):
         """If neither root_url nor leader_ip is available, skip bootstrap."""
-        self.harness.update_config({
-            "admin_email": "hello@ubuntu.com",
-            "admin_name": "Hello Ubuntu",
-            "admin_password": "password",
-        })
+        self.harness.update_config(
+            {
+                "admin_email": "hello@ubuntu.com",
+                "admin_name": "Hello Ubuntu",
+                "admin_password": "password",
+            }
+        )
         self.assertEqual(len(self._bootstrap_calls()), 0)
 
     @patch("charm.update_service_conf")
     def test_bootstrap_account_uses_leader_ip_when_no_root_url(self, _):
         self.harness.charm._stored.leader_ip = "10.0.0.1"
-        self.harness.update_config({
-            "admin_email": "hello@ubuntu.com",
-            "admin_name": "Hello Ubuntu",
-            "admin_password": "password",
-        })
+        self.harness.update_config(
+            {
+                "admin_email": "hello@ubuntu.com",
+                "admin_name": "Hello Ubuntu",
+                "admin_password": "password",
+            }
+        )
         calls = self._bootstrap_calls()
         self.assertEqual(len(calls), 1)
         self.assertIn(
@@ -2583,12 +2606,14 @@ class TestBootstrapAccount(unittest.TestCase):
         """If config root_url and leader_ip are both set, use config url"""
         self.harness.charm._stored.leader_ip = "10.0.0.1"
         config_root_url = "https://www.landscape.com"
-        self.harness.update_config({
-            "admin_email": "hello@ubuntu.com",
-            "admin_name": "Hello Ubuntu",
-            "admin_password": "password",
-            "root_url": config_root_url,
-        })
+        self.harness.update_config(
+            {
+                "admin_email": "hello@ubuntu.com",
+                "admin_name": "Hello Ubuntu",
+                "admin_password": "password",
+                "root_url": config_root_url,
+            }
+        )
         calls = self._bootstrap_calls()
         self.assertEqual(len(calls), 1)
         self.assertIn(config_root_url, calls[0].args[0])

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -3256,19 +3256,21 @@ class TestPackageInstall:
         )
 
         with (
-            patch("charm.apt", spec_set=apt) as apt_mock,
+            patch("charm.apt", spec_set=apt),
             patch("charm.check_call") as check_mock,
             patch("charm.prepend_default_settings"),
             patch("charm.update_service_conf"),
         ):
-            apt_mock.add_package.return_value = None
             ctx.run(ctx.on.install(), state)
 
-        apt_mock.add_package.assert_called_once_with(
-            [LANDSCAPE_SERVER], update_cache=True
-        )
-
         check_mock_call_args = [c.args[0] for c in check_mock.call_args_list]
+        assert [
+            "apt-get",
+            "install",
+            "--no-install-recommends",
+            "-y",
+            LANDSCAPE_SERVER,
+        ] in check_mock_call_args
         assert ["apt-mark", "hold", LANDSCAPE_SERVER] in check_mock_call_args
         assert ["apt-mark", "hold", LANDSCAPE_HOSTED] not in check_mock_call_args
         assert ["apt-mark", "hold", LANDSCAPE_HASH_IDS] not in check_mock_call_args

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1269,7 +1269,7 @@ class TestCharm(unittest.TestCase):
         )
         mocks["check_call"].assert_any_call(["apt-mark", "hold", "landscape-server"])
         mocks["apt"].add_package.assert_called_once_with(
-            ["landscape-server", LANDSCAPE_HASH_IDS],
+            ["landscape-server", "landscape-hashids"],
             update_cache=True,
         )
         mocks["snap"].add.assert_called_once_with(
@@ -3257,7 +3257,7 @@ class TestPackageInstall:
 
         with (
             patch("charm.apt", spec_set=apt) as apt_mock,
-            patch("charm.check_call"),
+            patch("charm.check_call") as check_mock,
             patch("charm.prepend_default_settings"),
             patch("charm.update_service_conf"),
         ):
@@ -3267,6 +3267,11 @@ class TestPackageInstall:
         apt_mock.add_package.assert_called_once_with(
             [LANDSCAPE_SERVER], update_cache=True
         )
+
+        check_mock_call_args = [c.args[0] for c in check_mock.call_args_list]
+        assert ["apt-mark", "hold", LANDSCAPE_SERVER] in check_mock_call_args
+        assert ["apt-mark", "hold", LANDSCAPE_HOSTED] not in check_mock_call_args
+        assert ["apt-mark", "hold", LANDSCAPE_HASH_IDS] not in check_mock_call_args
 
     def test_install_landscape_server_hashids(self):
         """
@@ -3284,7 +3289,7 @@ class TestPackageInstall:
 
         with (
             patch("charm.apt", spec_set=apt) as apt_mock,
-            patch("charm.check_call"),
+            patch("charm.check_call") as check_mock,
             patch("charm.prepend_default_settings"),
             patch("charm.update_service_conf"),
         ):
@@ -3294,6 +3299,11 @@ class TestPackageInstall:
         apt_mock.add_package.assert_called_once_with(
             [LANDSCAPE_SERVER, LANDSCAPE_HASH_IDS], update_cache=True
         )
+
+        check_mock_call_args = [c.args[0] for c in check_mock.call_args_list]
+        assert ["apt-mark", "hold", LANDSCAPE_SERVER] in check_mock_call_args
+        assert ["apt-mark", "hold", LANDSCAPE_HOSTED] not in check_mock_call_args
+        assert ["apt-mark", "hold", LANDSCAPE_HASH_IDS] in check_mock_call_args
 
     def test_install_landscape_server_hashids_hosted(self):
         """
@@ -3311,7 +3321,7 @@ class TestPackageInstall:
 
         with (
             patch("charm.apt", spec_set=apt) as apt_mock,
-            patch("charm.check_call"),
+            patch("charm.check_call") as check_mock,
             patch("charm.prepend_default_settings"),
             patch("charm.update_service_conf"),
         ):
@@ -3322,6 +3332,11 @@ class TestPackageInstall:
             [LANDSCAPE_SERVER, LANDSCAPE_HASH_IDS, LANDSCAPE_HOSTED],
             update_cache=True,
         )
+
+        check_mock_call_args = [c.args[0] for c in check_mock.call_args_list]
+        assert ["apt-mark", "hold", LANDSCAPE_SERVER] in check_mock_call_args
+        assert ["apt-mark", "hold", LANDSCAPE_HOSTED] in check_mock_call_args
+        assert ["apt-mark", "hold", LANDSCAPE_HASH_IDS] in check_mock_call_args
 
     def test_install_landscape_server_hosted(self):
         """
@@ -3339,7 +3354,7 @@ class TestPackageInstall:
 
         with (
             patch("charm.apt", spec_set=apt) as apt_mock,
-            patch("charm.check_call"),
+            patch("charm.check_call") as check_mock,
             patch("charm.prepend_default_settings"),
             patch("charm.update_service_conf"),
         ):
@@ -3350,3 +3365,8 @@ class TestPackageInstall:
             [LANDSCAPE_SERVER, LANDSCAPE_HOSTED],
             update_cache=True,
         )
+
+        check_mock_call_args = [c.args[0] for c in check_mock.call_args_list]
+        assert ["apt-mark", "hold", LANDSCAPE_SERVER] in check_mock_call_args
+        assert ["apt-mark", "hold", LANDSCAPE_HOSTED] in check_mock_call_args
+        assert ["apt-mark", "hold", LANDSCAPE_HASH_IDS] not in check_mock_call_args

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -3338,10 +3338,10 @@ class TestPackageInstall:
         assert ["apt-mark", "hold", LANDSCAPE_HOSTED] in check_mock_call_args
         assert ["apt-mark", "hold", LANDSCAPE_HASH_IDS] in check_mock_call_args
 
-    def test_install_landscape_server_hosted(self):
+    def test_install_landscape_server_hosted_min_install_blocked(self):
         """
-        When passing `min_install=true` and running in SaaS mode,
-        the landscape-server and landscape-hosted packages are installed.
+        min_install=True with a non-standalone deployment_mode is a config error
+        since landscape-hosted depends on landscape-hashids.
         """
         ctx = Context(LandscapeServerCharm)
         state = State(
@@ -3354,19 +3354,10 @@ class TestPackageInstall:
 
         with (
             patch("charm.apt", spec_set=apt) as apt_mock,
-            patch("charm.check_call") as check_mock,
+            patch("charm.check_call"),
             patch("charm.prepend_default_settings"),
             patch("charm.update_service_conf"),
+            ctx(ctx.on.install(), state) as mgr,
         ):
             apt_mock.add_package.return_value = None
-            ctx.run(ctx.on.install(), state)
-
-        apt_mock.add_package.assert_called_once_with(
-            [LANDSCAPE_SERVER, LANDSCAPE_HOSTED],
-            update_cache=True,
-        )
-
-        check_mock_call_args = [c.args[0] for c in check_mock.call_args_list]
-        assert ["apt-mark", "hold", LANDSCAPE_SERVER] in check_mock_call_args
-        assert ["apt-mark", "hold", LANDSCAPE_HOSTED] in check_mock_call_args
-        assert ["apt-mark", "hold", LANDSCAPE_HASH_IDS] not in check_mock_call_args
+            assert isinstance(mgr.charm.unit.status, BlockedStatus)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -4,6 +4,7 @@
 # Learn more about testing at
 # https://documentation.ubuntu.com/ops/latest/explanation/testing/
 
+import logging
 from grp import struct_group
 import json
 import os
@@ -1398,13 +1399,11 @@ class TestCharm(unittest.TestCase):
     ):
         root_url = "https://landscape.local/"
         system_email = "landscape-devel@lists.canonical.com"
-        self.harness.update_config(
-            {
-                "deployment_mode": "standalone",
-                "root_url": root_url,
-                "system_email": system_email,
-            }
-        )
+        self.harness.update_config({
+            "deployment_mode": "standalone",
+            "root_url": root_url,
+            "system_email": system_email,
+        })
 
         with (
             patch("charm.check_call") as check_call_mock,
@@ -1444,13 +1443,11 @@ class TestCharm(unittest.TestCase):
 
     @patch("charm.get_modified_env_vars", return_value={"PATH": "/usr/bin"})
     def test_migrate_schema_bootstrap_override_args(self, get_env):
-        self.harness.update_config(
-            {
-                "bootstrap_schema_override_args": (
-                    "--with-openstack,--with-extra-computers,10"
-                )
-            }
-        )
+        self.harness.update_config({
+            "bootstrap_schema_override_args": (
+                "--with-openstack,--with-extra-computers,10"
+            )
+        })
 
         with (
             patch("charm.check_call") as check_call_mock,
@@ -1592,9 +1589,9 @@ class TestCharm(unittest.TestCase):
     def test_update_ready_status_not_running(self):
         self.harness.charm.unit.status = WaitingStatus()
 
-        self.harness.charm._stored.ready.update(
-            {k: True for k in self.harness.charm._stored.ready.keys()}
-        )
+        self.harness.charm._stored.ready.update({
+            k: True for k in self.harness.charm._stored.ready.keys()
+        })
 
         patches = patch.multiple(
             "charm",
@@ -1616,9 +1613,9 @@ class TestCharm(unittest.TestCase):
     def test_update_ready_status_running(self):
         self.harness.charm.unit.status = WaitingStatus()
 
-        self.harness.charm._stored.ready.update(
-            {k: True for k in self.harness.charm._stored.ready.keys()}
-        )
+        self.harness.charm._stored.ready.update({
+            k: True for k in self.harness.charm._stored.ready.keys()
+        })
         self.harness.charm._stored.running = True
 
         self.harness.charm._update_ready_status()
@@ -1630,9 +1627,9 @@ class TestCharm(unittest.TestCase):
     def test_update_ready_status_called_process_error(self):
         self.harness.charm.unit.status = WaitingStatus()
 
-        self.harness.charm._stored.ready.update(
-            {k: True for k in self.harness.charm._stored.ready.keys()}
-        )
+        self.harness.charm._stored.ready.update({
+            k: True for k in self.harness.charm._stored.ready.keys()
+        })
 
         patches = patch.multiple(
             "charm",
@@ -1704,18 +1701,16 @@ class TestCharm(unittest.TestCase):
         self.assertIsInstance(status, BlockedStatus)
         self.assertFalse(self.harness.charm._stored.ready["db"])
 
-        update_service_conf_mock.assert_called_once_with(
-            {
-                "stores": {
-                    "host": "1.2.3.4:5678",
-                    "password": "testpass",
-                },
-                "schema": {
-                    "store_user": "testuser",
-                    "store_password": "testpass",
-                },
-            }
-        )
+        update_service_conf_mock.assert_called_once_with({
+            "stores": {
+                "host": "1.2.3.4:5678",
+                "password": "testpass",
+            },
+            "schema": {
+                "store_user": "testuser",
+                "store_password": "testpass",
+            },
+        })
 
     @patch("charm.update_service_conf")
     def test_on_manual_db_config_change(self, _):
@@ -1755,13 +1750,11 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(update_service_conf_mock.call_count, 2)
         self.assertEqual(
             update_service_conf_mock.call_args_list[1],
-            call(
-                {
-                    "stores": {
-                        "host": "hello:world",
-                    },
-                }
-            ),
+            call({
+                "stores": {
+                    "host": "hello:world",
+                },
+            }),
         )
 
     @patch("charm.update_service_conf")
@@ -1955,14 +1948,12 @@ class TestCharm(unittest.TestCase):
         self.assertTrue(self.harness.charm._stored.ready["inbound-amqp"])
         self.assertTrue(self.harness.charm._stored.ready["outbound-amqp"])
 
-        mock_update_conf.assert_called_once_with(
-            {
-                "broker": {
-                    "host": ",".join(hostname),
-                    "password": password,
-                },
-            }
-        )
+        mock_update_conf.assert_called_once_with({
+            "broker": {
+                "host": ",".join(hostname),
+                "password": password,
+            },
+        })
 
     def test_amqp_relation_changed_outbound_first(self):
         """
@@ -1999,14 +1990,12 @@ class TestCharm(unittest.TestCase):
         self.assertTrue(self.harness.charm._stored.ready["inbound-amqp"])
         self.assertTrue(self.harness.charm._stored.ready["outbound-amqp"])
 
-        mock_update_conf.assert_called_once_with(
-            {
-                "broker": {
-                    "host": hostname,
-                    "password": password,
-                },
-            }
-        )
+        mock_update_conf.assert_called_once_with({
+            "broker": {
+                "host": hostname,
+                "password": password,
+            },
+        })
 
     def test_configure_smtp_relay_host(self):
         mock_postfix_cf = os.path.join(self.tempdir.name, "my_postfix.cf")
@@ -2406,13 +2395,11 @@ class TestCharm(unittest.TestCase):
             )
 
         self.harness.charm._update_nrpe_checks.assert_called_once()
-        mock_update_conf.assert_called_once_with(
-            {
-                "package-search": {
-                    "host": "localhost",
-                },
-            }
-        )
+        mock_update_conf.assert_called_once_with({
+            "package-search": {
+                "host": "localhost",
+            },
+        })
 
     def test_on_replicas_relation_changed_non_leader(self):
         """
@@ -2432,13 +2419,11 @@ class TestCharm(unittest.TestCase):
             )
 
         self.harness.charm._update_nrpe_checks.assert_called_once()
-        mock_update_conf.assert_called_once_with(
-            {
-                "package-search": {
-                    "host": "test",
-                },
-            }
-        )
+        mock_update_conf.assert_called_once_with({
+            "package-search": {
+                "host": "test",
+            },
+        })
 
 
 class TestMultiplePPAs:
@@ -2547,12 +2532,10 @@ class TestBootstrapAccount(unittest.TestCase):
 
     @patch("charm.update_service_conf")
     def test_bootstrap_account_doesnt_run_with_missing_configs(self, _):
-        self.harness.update_config(
-            {
-                "admin_email": "hello@ubuntu.com",
-                "admin_name": "Hello Ubuntu",
-            }
-        )
+        self.harness.update_config({
+            "admin_email": "hello@ubuntu.com",
+            "admin_name": "Hello Ubuntu",
+        })
         self.log_mock.assert_any_call(
             "Admin email, name, and password required for bootstrap account"
         )
@@ -2560,40 +2543,34 @@ class TestBootstrapAccount(unittest.TestCase):
 
     @patch("charm.update_service_conf")
     def test_bootstrap_account_password_redacted(self, _):
-        self.harness.update_config(
-            {
-                "admin_email": "hello@ubuntu.com",
-                "admin_name": "Hello Ubuntu",
-                "admin_password": "secret123",
-                "registration_key": "secret123",
-                "root_url": "https://www.landscape.com",
-            }
-        )
+        self.harness.update_config({
+            "admin_email": "hello@ubuntu.com",
+            "admin_name": "Hello Ubuntu",
+            "admin_password": "secret123",
+            "registration_key": "secret123",
+            "root_url": "https://www.landscape.com",
+        })
         for mock_call in self.log_info_mock.call_args_list:
             self.assertNotIn("secret123", str(mock_call.args))
 
     @patch("charm.update_service_conf")
     def test_bootstrap_account_skips_when_no_root_url_and_no_leader_ip(self, _):
         """If neither root_url nor leader_ip is available, skip bootstrap."""
-        self.harness.update_config(
-            {
-                "admin_email": "hello@ubuntu.com",
-                "admin_name": "Hello Ubuntu",
-                "admin_password": "password",
-            }
-        )
+        self.harness.update_config({
+            "admin_email": "hello@ubuntu.com",
+            "admin_name": "Hello Ubuntu",
+            "admin_password": "password",
+        })
         self.assertEqual(len(self._bootstrap_calls()), 0)
 
     @patch("charm.update_service_conf")
     def test_bootstrap_account_uses_leader_ip_when_no_root_url(self, _):
         self.harness.charm._stored.leader_ip = "10.0.0.1"
-        self.harness.update_config(
-            {
-                "admin_email": "hello@ubuntu.com",
-                "admin_name": "Hello Ubuntu",
-                "admin_password": "password",
-            }
-        )
+        self.harness.update_config({
+            "admin_email": "hello@ubuntu.com",
+            "admin_name": "Hello Ubuntu",
+            "admin_password": "password",
+        })
         calls = self._bootstrap_calls()
         self.assertEqual(len(calls), 1)
         self.assertIn(
@@ -2606,14 +2583,12 @@ class TestBootstrapAccount(unittest.TestCase):
         """If config root_url and leader_ip are both set, use config url"""
         self.harness.charm._stored.leader_ip = "10.0.0.1"
         config_root_url = "https://www.landscape.com"
-        self.harness.update_config(
-            {
-                "admin_email": "hello@ubuntu.com",
-                "admin_name": "Hello Ubuntu",
-                "admin_password": "password",
-                "root_url": config_root_url,
-            }
-        )
+        self.harness.update_config({
+            "admin_email": "hello@ubuntu.com",
+            "admin_name": "Hello Ubuntu",
+            "admin_password": "password",
+            "root_url": config_root_url,
+        })
         calls = self._bootstrap_calls()
         self.assertEqual(len(calls), 1)
         self.assertIn(config_root_url, calls[0].args[0])
@@ -3237,3 +3212,115 @@ class TestSchemaFlags:
             ctx.run(ctx.on.action("migrate-schema"), state)
 
         assert isinstance(ctx.action_results, dict) or ctx.action_results is None
+
+
+class TestPackageInstall:
+    def test_install_only_landscape_server(self):
+        """
+        When passing `min_install=true` and running in standalone mode,
+        only the landscape-server package is installed.
+        """
+        ctx = Context(LandscapeServerCharm)
+        state = State(
+            unit_status=MaintenanceStatus(),
+            config={
+                "min_install": True,
+                "deployment_mode": "standalone",
+            },
+        )
+
+        with (
+            patch("charm.apt", spec_set=apt) as apt_mock,
+            patch("charm.check_call"),
+            patch("charm.prepend_default_settings"),
+            patch("charm.update_service_conf"),
+        ):
+            apt_mock.add_package.return_value = None
+            ctx.run(ctx.on.install(), state)
+
+        apt_mock.add_package.assert_called_once_with(
+            ["landscape-server"], update_cache=True
+        )
+
+    def test_install_landscape_server_hashids(self):
+        """
+        When passing `min_install=false` and running in standalone mode,
+        only the landscape-server package is installed.
+        """
+        ctx = Context(LandscapeServerCharm)
+        state = State(
+            unit_status=MaintenanceStatus(),
+            config={
+                "min_install": False,
+                "deployment_mode": "standalone",
+            },
+        )
+
+        with (
+            patch("charm.apt", spec_set=apt) as apt_mock,
+            patch("charm.check_call"),
+            patch("charm.prepend_default_settings"),
+            patch("charm.update_service_conf"),
+        ):
+            apt_mock.add_package.return_value = None
+            ctx.run(ctx.on.install(), state)
+
+        apt_mock.add_package.assert_called_once_with(
+            ["landscape-server", "landscape-hashids"], update_cache=True
+        )
+
+    def test_install_landscape_server_hashids_hosted(self):
+        """
+        When passing `min_install=false` and running in SaaS mode,
+        only the landscape-server package is installed.
+        """
+        ctx = Context(LandscapeServerCharm)
+        state = State(
+            unit_status=MaintenanceStatus(),
+            config={
+                "min_install": False,
+                "deployment_mode": "saas",
+            },
+        )
+
+        with (
+            patch("charm.apt", spec_set=apt) as apt_mock,
+            patch("charm.check_call"),
+            patch("charm.prepend_default_settings"),
+            patch("charm.update_service_conf"),
+        ):
+            apt_mock.add_package.return_value = None
+            ctx.run(ctx.on.install(), state)
+
+        apt_mock.add_package.assert_called_once_with(
+            ["landscape-server", "landscape-hashids", "landscape-hosted"],
+            update_cache=True,
+        )
+
+    def test_install_landscape_server_hosted(self):
+        """
+        When passing `min_install=false` and running in SaaS mode,
+        only the landscape-server package is installed.
+        """
+        ctx = Context(LandscapeServerCharm)
+        state = State(
+            unit_status=MaintenanceStatus(),
+            config={
+                "min_install": True,
+                "deployment_mode": "saas",
+            },
+        )
+
+        with (
+            patch("charm.apt", spec_set=apt) as apt_mock,
+            patch("charm.check_call"),
+            patch("charm.prepend_default_settings"),
+            patch("charm.update_service_conf"),
+        ):
+            apt_mock.add_package.return_value = None
+            ctx.run(ctx.on.install(), state)
+
+        apt_mock.add_package.assert_called_once_with(
+            ["landscape-server", "landscape-hosted"],
+            update_cache=True,
+        )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -3310,7 +3310,7 @@ class TestPackageInstall:
     def test_install_landscape_server_hashids_hosted(self):
         """
         When passing `min_install=false` and running in SaaS mode,
-        only the all three packages are installed.
+        all three packages are installed.
         """
         ctx = Context(LandscapeServerCharm)
         state = State(

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -268,6 +268,40 @@ def test_landscape_ppas_strips_whitespace():
     assert config.landscape_ppas == ["ppa:foo/bar", "ppa:baz/qux"]
 
 
+@pytest.mark.parametrize(
+    "min_install,deployment_mode",
+    [
+        (True, "standalone"),
+        (False, "standalone"),
+        (False, "saas"),
+        (False, "my-custom-mode"),
+    ],
+)
+def test_min_install_valid_combinations(min_install, deployment_mode):
+    config = LandscapeCharmConfiguration(
+        **{
+            **get_config_defaults(),
+            "min_install": min_install,
+            "deployment_mode": deployment_mode,
+        }
+    )
+    assert config.min_install == min_install
+    assert config.deployment_mode == deployment_mode
+
+
+@pytest.mark.parametrize("deployment_mode", ["saas", "my-custom-mode"])
+def test_min_install_invalid_with_non_standalone(deployment_mode):
+    """min_install=True is blocked for non-standalone deployments."""
+    with pytest.raises(ValidationError, match="min_install=True is not compatible"):
+        LandscapeCharmConfiguration(
+            **{
+                **get_config_defaults(),
+                "min_install": True,
+                "deployment_mode": deployment_mode,
+            }
+        )
+
+
 def test_bootstrap_schema_override_args_list():
     config = LandscapeCharmConfiguration(
         **{


### PR DESCRIPTION
https://warthogs.atlassian.net/browse/LNDENG-4584

## Manual testing

Deploy in SaaS mode: 

```sh
make BUNDLE_PATH=./bundle-examples/saas.bundle.yaml deploy 
```

After the install finishes, verify the self-hosted and SaaS cron jobs are there:
```sh
juju ssh landscape-server/0 "sudo cat /etc/cron.d/landscape-server"
juju ssh landscape-server/0 "sudo cat /etc/cron.d/landscape-hosted"
```

Should have all three packages:

```sh
juju ssh landscape-server/0 "sudo apt policy landscape-server"
juju ssh landscape-server/0 "sudo apt policy landscape-hashids"
juju ssh landscape-server/0 "sudo apt policy landscape-hosted"
```

Now, deploy in min_install standalone:

```sh
make deploy 
```

Only `landscape-server` should be installed:

```sh
juju ssh landscape-server/0 "sudo apt policy landscape-server"
juju ssh landscape-server/0 "sudo apt policy landscape-hashids"
juju ssh landscape-server/0 "sudo apt policy landscape-hosted"
```
