### PR TITLE
feat: add config option for analytics_id

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -165,6 +165,14 @@ options:
       Landscape Server tenancy mode - do not modify unless you are able
       to provide the additional configuration required to run
       Landscape in SaaS mode.
+  analytics_id:
+    type: string
+    default:
+    description: |
+      Google Analytics tracker ID exposed to Landscape Server as the
+      LANDSCAPE_ANALYTICS_ID environment variable. When unset, Landscape
+      falls back to its built-in tracker ID for the configured
+      deployment mode.
   additional_service_config:
     type: string
     default:

--- a/src/charm.py
+++ b/src/charm.py
@@ -92,6 +92,7 @@ from settings_files import (
     update_default_settings,
     update_service_conf,
     VHOSTS,
+    write_analytics_id_systemd_override,
     write_deployment_mode_systemd_override,
     write_license_file,
 )
@@ -500,6 +501,7 @@ class LandscapeServerCharm(CharmBase):
         )
         configure_for_deployment_mode(self.charm_config.deployment_mode)
         write_deployment_mode_systemd_override(self.charm_config.deployment_mode)
+        write_analytics_id_systemd_override(self.charm_config.analytics_id)
 
         service_conf_updates = {
             service: {"workers": str(self.charm_config.worker_counts)}

--- a/src/config.py
+++ b/src/config.py
@@ -104,6 +104,21 @@ class LandscapeCharmConfiguration(BaseModel):
 
         return v
 
+    @field_validator("analytics_id")
+    @classmethod
+    def analytics_id_safe_chars(cls, v: str | None):
+        if v is None:
+            return None
+        v = v.strip()
+        if not v:
+            return None
+        if not re.fullmatch(r"[A-Za-z0-9_.-]+", v):
+            raise ValueError(
+                f"analytics_id {v!r} contains invalid characters. "
+                "Only letters, numbers, dots, hyphens, and underscores are allowed."
+            )
+        return v
+
     @model_validator(mode="after")
     def openid_oidc_exclusive(self):
         OPENID_CONFIGS = (

--- a/src/config.py
+++ b/src/config.py
@@ -60,6 +60,7 @@ class LandscapeCharmConfiguration(BaseModel):
     db_schema_user: str | None = None
     db_schema_password: str | None = None
     deployment_mode: str
+    analytics_id: str | None = None
     additional_service_config: str | None = None
     secret_token: str | None = None
     cookie_encryption_key: str | None = None

--- a/src/settings_files.py
+++ b/src/settings_files.py
@@ -74,6 +74,8 @@ _SERVICES_WITH_HARDCODED_DEPLOYMENT_MODE = [
 
 _DEPLOYMENT_MODE_OVERRIDE_CONF = "deployment-mode.conf"
 
+_ANALYTICS_ID_OVERRIDE_CONF = "analytics-id.conf"
+
 
 def write_deployment_mode_systemd_override(mode: str) -> None:
     """
@@ -88,6 +90,30 @@ def write_deployment_mode_systemd_override(mode: str) -> None:
         with open(os.path.join(override_dir, _DEPLOYMENT_MODE_OVERRIDE_CONF), "w") as f:
             f.write("[Service]\n")
             f.write(f"Environment=LANDSCAPE_SYSTEM__DEPLOYMENT_MODE={mode}\n")
+    daemon_reload()
+
+
+def write_analytics_id_systemd_override(analytics_id: str | None) -> None:
+    """
+    Writes (or removes) a systemd drop-in per service to set LANDSCAPE_ANALYTICS_ID.
+
+    Landscape reads this environment variable to select the Google Analytics
+    tracker ID, overriding the built-in default for the deployment mode. When
+    analytics_id is empty, any existing drop-in is removed so Landscape falls
+    back to its default.
+    """
+    for service in _SERVICES_WITH_HARDCODED_DEPLOYMENT_MODE:
+        override_dir = f"/etc/systemd/system/{service}.d"
+        override_path = os.path.join(override_dir, _ANALYTICS_ID_OVERRIDE_CONF)
+
+        if analytics_id:
+            os.makedirs(override_dir, exist_ok=True)
+            with open(override_path, "w") as f:
+                f.write("[Service]\n")
+                f.write(f"Environment=LANDSCAPE_ANALYTICS_ID={analytics_id}\n")
+        elif os.path.exists(override_path):
+            os.remove(override_path)
+
     daemon_reload()
 
 

--- a/src/settings_files.py
+++ b/src/settings_files.py
@@ -76,6 +76,9 @@ _DEPLOYMENT_MODE_OVERRIDE_CONF = "deployment-mode.conf"
 
 _ANALYTICS_ID_OVERRIDE_CONF = "analytics-id.conf"
 
+# Only the web frontend renders the Google Analytics tracker into HTML pages.
+_ANALYTICS_SERVICE = "landscape-appserver.service"
+
 
 def write_deployment_mode_systemd_override(mode: str) -> None:
     """
@@ -95,24 +98,24 @@ def write_deployment_mode_systemd_override(mode: str) -> None:
 
 def write_analytics_id_systemd_override(analytics_id: str | None) -> None:
     """
-    Writes (or removes) a systemd drop-in per service to set LANDSCAPE_ANALYTICS_ID.
+    Writes (or removes) a systemd drop-in for the appserver to set
+    LANDSCAPE_ANALYTICS_ID.
 
     Landscape reads this environment variable to select the Google Analytics
     tracker ID, overriding the built-in default for the deployment mode. When
     analytics_id is empty, any existing drop-in is removed so Landscape falls
     back to its default.
     """
-    for service in _SERVICES_WITH_HARDCODED_DEPLOYMENT_MODE:
-        override_dir = f"/etc/systemd/system/{service}.d"
-        override_path = os.path.join(override_dir, _ANALYTICS_ID_OVERRIDE_CONF)
+    override_dir = f"/etc/systemd/system/{_ANALYTICS_SERVICE}.d"
+    override_path = os.path.join(override_dir, _ANALYTICS_ID_OVERRIDE_CONF)
 
-        if analytics_id:
-            os.makedirs(override_dir, exist_ok=True)
-            with open(override_path, "w") as f:
-                f.write("[Service]\n")
-                f.write(f"Environment=LANDSCAPE_ANALYTICS_ID={analytics_id}\n")
-        elif os.path.exists(override_path):
-            os.remove(override_path)
+    if analytics_id:
+        os.makedirs(override_dir, exist_ok=True)
+        with open(override_path, "w") as f:
+            f.write("[Service]\n")
+            f.write(f"Environment=LANDSCAPE_ANALYTICS_ID={analytics_id}\n")
+    elif os.path.exists(override_path):
+        os.remove(override_path)
 
     daemon_reload()
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -26,6 +26,13 @@ def mock_write_deployment_mode_systemd_override(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def mock_write_analytics_id_systemd_override(monkeypatch):
+    monkeypatch.setattr(
+        "charm.write_analytics_id_systemd_override", lambda *a, **kw: None
+    )
+
+
+@pytest.fixture(autouse=True)
 def capture_service_conf(tmp_path, monkeypatch) -> ConfigReader:
     """
     Redirect all writes to `SERVICE_CONF` to a tempfile within this fixture.

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -682,6 +682,20 @@ root-url = https://overridden.example.com
         ctx.run(ctx.on.config_changed(), state)
         assert calls == ["prod"]
 
+    def test_analytics_id_override_called(
+        self,
+        monkeypatch,
+    ):
+        calls = []
+        monkeypatch.setattr(
+            "charm.write_analytics_id_systemd_override",
+            lambda analytics_id: calls.append(analytics_id),
+        )
+        ctx = Context(LandscapeServerCharm)
+        state = State(config={"analytics_id": "UA-1018242-13"})
+        ctx.run(ctx.on.config_changed(), state)
+        assert calls == ["UA-1018242-13"]
+
     def test_hostagent_services_disable_closes_port(
         self,
         replicas_network_state,

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -238,6 +238,30 @@ def test_deployment_mode_invalid(mode):
         LandscapeCharmConfiguration(**defaults)
 
 
+@pytest.mark.parametrize("analytics_id", ["UA-1018242-13", "G_TAG.1", "abc_123"])
+def test_analytics_id_valid(analytics_id):
+    defaults = get_config_defaults()
+    defaults["analytics_id"] = analytics_id
+    config = LandscapeCharmConfiguration(**defaults)
+    assert config.analytics_id == analytics_id
+
+
+@pytest.mark.parametrize("analytics_id,expected", [("", None), ("  ", None)])
+def test_analytics_id_blank_becomes_none(analytics_id, expected):
+    defaults = get_config_defaults()
+    defaults["analytics_id"] = analytics_id
+    config = LandscapeCharmConfiguration(**defaults)
+    assert config.analytics_id is expected
+
+
+@pytest.mark.parametrize("analytics_id", ["bad id", "bad;id", "id\ninjection"])
+def test_analytics_id_invalid(analytics_id):
+    defaults = get_config_defaults()
+    defaults["analytics_id"] = analytics_id
+    with pytest.raises(ValidationError, match="contains invalid characters"):
+        LandscapeCharmConfiguration(**defaults)
+
+
 def test_landscape_ppas_single():
     config = LandscapeCharmConfiguration(
         **{

--- a/tests/unit/test_settings_files.py
+++ b/tests/unit/test_settings_files.py
@@ -12,6 +12,7 @@ import pytest
 
 from settings_files import (
     _ANALYTICS_ID_OVERRIDE_CONF,
+    _ANALYTICS_SERVICE,
     _DEPLOYMENT_MODE_OVERRIDE_CONF,
     _SERVICES_WITH_HARDCODED_DEPLOYMENT_MODE,
     CONFIGS_DIR,
@@ -128,26 +129,24 @@ class TestWriteDeploymentModeSystemdOverride:
 
 @pytest.mark.usefixtures("redirect_systemd_paths")
 class TestWriteAnalyticsIdSystemdOverride:
-    def test_writes_drop_in_for_each_service(self, monkeypatch, tmp_path):
+    def test_writes_drop_in_for_appserver(self, monkeypatch, tmp_path):
         monkeypatch.setattr("settings_files.daemon_reload", lambda: None)
 
         write_analytics_id_systemd_override("UA-1018242-13")
 
-        for service in _SERVICES_WITH_HARDCODED_DEPLOYMENT_MODE:
-            drop_in = tmp_path / f"{service}.d" / _ANALYTICS_ID_OVERRIDE_CONF
-            assert drop_in.exists()
+        drop_in = tmp_path / f"{_ANALYTICS_SERVICE}.d" / _ANALYTICS_ID_OVERRIDE_CONF
+        assert drop_in.exists()
 
     def test_drop_in_content(self, monkeypatch, tmp_path):
         monkeypatch.setattr("settings_files.daemon_reload", lambda: None)
 
         write_analytics_id_systemd_override("UA-1018242-13")
 
-        for service in _SERVICES_WITH_HARDCODED_DEPLOYMENT_MODE:
-            content = (
-                tmp_path / f"{service}.d" / _ANALYTICS_ID_OVERRIDE_CONF
-            ).read_text()
-            assert "[Service]" in content
-            assert "Environment=LANDSCAPE_ANALYTICS_ID=UA-1018242-13" in content
+        content = (
+            tmp_path / f"{_ANALYTICS_SERVICE}.d" / _ANALYTICS_ID_OVERRIDE_CONF
+        ).read_text()
+        assert "[Service]" in content
+        assert "Environment=LANDSCAPE_ANALYTICS_ID=UA-1018242-13" in content
 
     def test_empty_id_removes_existing_drop_in(self, monkeypatch, tmp_path):
         monkeypatch.setattr("settings_files.daemon_reload", lambda: None)
@@ -155,9 +154,8 @@ class TestWriteAnalyticsIdSystemdOverride:
         write_analytics_id_systemd_override("UA-1018242-13")
         write_analytics_id_systemd_override("")
 
-        for service in _SERVICES_WITH_HARDCODED_DEPLOYMENT_MODE:
-            drop_in = tmp_path / f"{service}.d" / _ANALYTICS_ID_OVERRIDE_CONF
-            assert not drop_in.exists()
+        drop_in = tmp_path / f"{_ANALYTICS_SERVICE}.d" / _ANALYTICS_ID_OVERRIDE_CONF
+        assert not drop_in.exists()
 
     def test_calls_daemon_reload(self, monkeypatch, tmp_path):
         called = []

--- a/tests/unit/test_settings_files.py
+++ b/tests/unit/test_settings_files.py
@@ -129,14 +129,6 @@ class TestWriteDeploymentModeSystemdOverride:
 
 @pytest.mark.usefixtures("redirect_systemd_paths")
 class TestWriteAnalyticsIdSystemdOverride:
-    def test_writes_drop_in_for_appserver(self, monkeypatch, tmp_path):
-        monkeypatch.setattr("settings_files.daemon_reload", lambda: None)
-
-        write_analytics_id_systemd_override("UA-1018242-13")
-
-        drop_in = tmp_path / f"{_ANALYTICS_SERVICE}.d" / _ANALYTICS_ID_OVERRIDE_CONF
-        assert drop_in.exists()
-
     def test_drop_in_content(self, monkeypatch, tmp_path):
         monkeypatch.setattr("settings_files.daemon_reload", lambda: None)
 

--- a/tests/unit/test_settings_files.py
+++ b/tests/unit/test_settings_files.py
@@ -11,6 +11,7 @@ from urllib.error import URLError
 import pytest
 
 from settings_files import (
+    _ANALYTICS_ID_OVERRIDE_CONF,
     _DEPLOYMENT_MODE_OVERRIDE_CONF,
     _SERVICES_WITH_HARDCODED_DEPLOYMENT_MODE,
     CONFIGS_DIR,
@@ -22,6 +23,7 @@ from settings_files import (
     read_service_conf,
     update_default_settings,
     update_service_conf,
+    write_analytics_id_systemd_override,
     write_deployment_mode_systemd_override,
     write_license_file,
 )
@@ -78,6 +80,19 @@ def redirect_systemd_paths(monkeypatch, tmp_path):
 
     monkeypatch.setattr("builtins.open", fake_open)
 
+    real_exists = os.path.exists
+
+    def fake_exists(path):
+        return real_exists(path.replace("/etc/systemd/system", str(tmp_path)))
+
+    monkeypatch.setattr("settings_files.os.path.exists", fake_exists)
+    real_remove = os.remove
+
+    def fake_remove(path):
+        return real_remove(path.replace("/etc/systemd/system", str(tmp_path)))
+
+    monkeypatch.setattr("settings_files.os.remove", fake_remove)
+
 
 @pytest.mark.usefixtures("redirect_systemd_paths")
 class TestWriteDeploymentModeSystemdOverride:
@@ -107,6 +122,48 @@ class TestWriteDeploymentModeSystemdOverride:
         monkeypatch.setattr("settings_files.daemon_reload", lambda: called.append(True))
 
         write_deployment_mode_systemd_override("prod")
+
+        assert called == [True]
+
+
+@pytest.mark.usefixtures("redirect_systemd_paths")
+class TestWriteAnalyticsIdSystemdOverride:
+    def test_writes_drop_in_for_each_service(self, monkeypatch, tmp_path):
+        monkeypatch.setattr("settings_files.daemon_reload", lambda: None)
+
+        write_analytics_id_systemd_override("UA-1018242-13")
+
+        for service in _SERVICES_WITH_HARDCODED_DEPLOYMENT_MODE:
+            drop_in = tmp_path / f"{service}.d" / _ANALYTICS_ID_OVERRIDE_CONF
+            assert drop_in.exists()
+
+    def test_drop_in_content(self, monkeypatch, tmp_path):
+        monkeypatch.setattr("settings_files.daemon_reload", lambda: None)
+
+        write_analytics_id_systemd_override("UA-1018242-13")
+
+        for service in _SERVICES_WITH_HARDCODED_DEPLOYMENT_MODE:
+            content = (
+                tmp_path / f"{service}.d" / _ANALYTICS_ID_OVERRIDE_CONF
+            ).read_text()
+            assert "[Service]" in content
+            assert "Environment=LANDSCAPE_ANALYTICS_ID=UA-1018242-13" in content
+
+    def test_empty_id_removes_existing_drop_in(self, monkeypatch, tmp_path):
+        monkeypatch.setattr("settings_files.daemon_reload", lambda: None)
+
+        write_analytics_id_systemd_override("UA-1018242-13")
+        write_analytics_id_systemd_override("")
+
+        for service in _SERVICES_WITH_HARDCODED_DEPLOYMENT_MODE:
+            drop_in = tmp_path / f"{service}.d" / _ANALYTICS_ID_OVERRIDE_CONF
+            assert not drop_in.exists()
+
+    def test_calls_daemon_reload(self, monkeypatch, tmp_path):
+        called = []
+        monkeypatch.setattr("settings_files.daemon_reload", lambda: called.append(True))
+
+        write_analytics_id_systemd_override("UA-1018242-13")
 
         assert called == [True]
 


### PR DESCRIPTION
adds config option for setting LANDSCAPE_ANALYTICS_ID to support PS7 (which uses prod/stg deployment modes vs production/staging)


manual testing:

in bundle-examples/bundle.yaml:
set min_install = False

```bash
make deploy
```

wait for landscape server to start up

```bash
juju config landscape-server deployment_mode=prod
```

go to the legacy UI and check that the "Manage your tracker settings" button doesn't appear on the bottom bar

```bash
juju config landscape-server analytics_id=UA-1018242-13
```

check that the tracker settings button appears

```bash
juju ssh landscape-server/leader -- 'systemctl show landscape-appserver.service -p Environment | grep LANDSCAPE_ANALYTICS_ID'
```

Check the environment variables include `LANDSCAPE_ANALYTICS_ID`
